### PR TITLE
Use location owned by nginx user for html root

### DIFF
--- a/nginx/production/nginx.conf
+++ b/nginx/production/nginx.conf
@@ -32,7 +32,7 @@ http {
         listen       80;
         listen       [::]:80;
         server_name  rhi.zone;
-        root         /home/ec2-user/rhizone-lms/webapp/build;
+        root         /usr/share/nginx/html;
 
         listen 443 ssl; # managed by Certbot
 


### PR DESCRIPTION
Just one tweak to make deploying the webapp easier. Permissions are already setup on this folder, so deploy is just `cp` from `build` to this folder.