### PR TITLE
Use correct paths for TLS certificates for api.rhi.zone

### DIFF
--- a/nginx/production/nginx.conf
+++ b/nginx/production/nginx.conf
@@ -62,8 +62,8 @@ http {
         listen 443 ssl; # managed by Certbot
 
         # RSA certificate
-        ssl_certificate /etc/letsencrypt/live/rhi.zone/fullchain.pem; # managed by Certbot
-        ssl_certificate_key /etc/letsencrypt/live/rhi.zone/privkey.pem; # managed by Certbot
+        ssl_certificate /etc/letsencrypt/live/api.rhi.zone/fullchain.pem; # managed by Certbot
+        ssl_certificate_key /etc/letsencrypt/live/api.rhi.zone/privkey.pem; # managed by Certbot
 
         include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
 


### PR DESCRIPTION
Separate certificate was provisioned for api.rhi.zone, so the paths in the nginx.conf need to reflect that.