### PR TITLE
App server is HTTP, Nginx proxy is HTTPS, 1st proxy must be trusted

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -29,6 +29,8 @@ app.use(helmet());
 
 app.use(bodyParser.json());
 
+app.set('trust proxy', 1);
+
 app.use(
   session({
     secret: process.env.SESSION_SECRET || 'default session secret',


### PR DESCRIPTION
Cookies weren't being set because the `Secure` attribute was set to `true` in production, but the application server is not HTTPS.

From [express-session](https://www.npmjs.com/package/express-session):

> Please note that secure: true is a recommended option. However, it requires an https-enabled website, i.e., HTTPS is necessary for secure cookies. If secure is set, and you access your site over HTTP, the cookie will not be set. If you have your node.js behind a proxy and are using secure: true, you need to set "trust proxy" in express