### PR TITLE
Preserve whitespace on journal entry cards

### DIFF
--- a/webapp/src/components/JournalEntriesList.tsx
+++ b/webapp/src/components/JournalEntriesList.tsx
@@ -13,7 +13,13 @@ const JournalEntriesList = ({ journalEntries }: JournalEntriesListProps) => (
     <Stack spacing={2}>
       {journalEntries.map(({ id, raw_text: rawText }) => (
         <Card key={id}>
-          <CardContent>{rawText}</CardContent>
+          <CardContent
+            sx={{
+              whiteSpace: 'pre-wrap',
+            }}
+          >
+            {rawText}
+          </CardContent>
         </Card>
       ))}
     </Stack>


### PR DESCRIPTION
## Proposed changes

The whitespaces are now preserved in the card element after saving the journal entries. Resolves #50.

## Checklist

- [x] Are the issues being addressed linked to this PR? 
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?

## Screenshots

![preserved whitespace](https://user-images.githubusercontent.com/59664677/139945480-d6ae4d06-ac7e-454f-8fc9-2dd25cac48f2.JPG)
