### PR TITLE
Add nullable column reflection_id to journal_entries

### DIFF
--- a/db/migration/V006__add_reflection_id_to_journal_entries.sql
+++ b/db/migration/V006__add_reflection_id_to_journal_entries.sql
@@ -1,0 +1,4 @@
+ALTER TABLE journal_entries 
+    ADD COLUMN reflection_id BIGINT,
+    ADD INDEX journal_entries_reflection_id (reflection_id),
+    ADD FOREIGN KEY (reflection_id) REFERENCES reflections(id);


### PR DESCRIPTION
## Proposed changes

Add nullable column reflection_id to journal_entries table so journal entries can be associated with reflections.

```
Successfully validated 6 migrations (execution time 00:00.115s)
Current version of schema `rhi-zone-db`: 005
Migrating schema `rhi-zone-db` to version "006 - add reflection id"
Successfully applied 1 migration to schema `rhi-zone-db`, now at version v006 (execution time 00:00.390s)
```

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
