### PR TITLE
Add browser setting instructions to stop default scrips from running

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -8,6 +8,8 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 1. Follow the instructions in `nginx/README.md`.
 2. Create a file named `.env.development.local`.
    1. Set `REACT_APP_API_ORIGIN` to `http://api.rhi.zone-development`.
+   2. Set `BROWSER` to `none` to override browser's default behaviour. Instead Nginx will be used to reverse proxy requests to dev servers and resolve dev domains to Nginx.
+   See docs here: https://create-react-app.dev/docs/advanced-configuration/
 
 ## Available Scripts
 


### PR DESCRIPTION
## Proposed changes

Add instruction to web apps README file on how to disable browser's default behavior of opening the app on localhost:3000 because it is the wrong page.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
