### PR TITLE
Add unique constraint to github_users.github_id

### DIFF
--- a/db/migration/V009__add_unique_github_users_github_id.sql
+++ b/db/migration/V009__add_unique_github_users_github_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE github_users
+  ADD CONSTRAINT unique_github_id
+  UNIQUE (github_id);


### PR DESCRIPTION
## Proposed changes


Add a unique constraint to github_id column in github_users table to disallow the insertion of multiple github_users with the same github_id.

After running `flyway migrate`, the output message is
```
Successfully applied 1 migration to schema `rhizone_development`, now at version v007
```

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
