### PR TITLE
Fill all null journal_entries.reflection_id and add not null constraint

### DIFF
--- a/db/migration/V007__backfill_journal_entry_reflections.sql
+++ b/db/migration/V007__backfill_journal_entry_reflections.sql
@@ -1,14 +1,13 @@
 CREATE PROCEDURE createReflectionsAndAssignToJournalEntries()
 BEGIN
-    iterate:
-    LOOP
+    loopLabel: LOOP
         SET @countUnassignedJournalEntries = (
             SELECT COUNT(*)
                 FROM journal_entries
                 WHERE reflection_id IS NULL
         );
         IF (@countUnassignedJournalEntries = 0) THEN
-            LEAVE iterate;
+            LEAVE loopLabel;
         END IF;
         INSERT INTO reflections (principal_id)
             SELECT principal_id
@@ -21,7 +20,7 @@ BEGIN
             WHERE reflection_id IS NULL
             ORDER BY journal_entries.id
             LIMIT 1;
-    END LOOP iterate;
+    END LOOP loopLabel;
 END;
 
 CALL createReflectionsAndAssignToJournalEntries();


### PR DESCRIPTION
# 🚨 DO NOT RUN UNTIL AFTER #65 IS SHIPPED 🚨

## Proposed changes

Creates reflections for all journal entries that were created before reflections existed, then fills `journal_entries.reflection_id` that are `NULL` with IDs from new reflections.

After there are no more `NULL` values in `journal_entries.reflection_id`, adds a `NOT NULL` constraint to that column.

Resolves #63.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?

## Testing

### Before

```
mysql> select * from principals;
+----+---------------------+---------------------+-------------+
| id | created_at          | updated_at          | entity_type |
+----+---------------------+---------------------+-------------+
|  1 | 2021-11-11 11:17:29 | 2021-11-11 11:17:29 | user        |
|  2 | 2021-11-11 11:17:29 | 2021-11-11 11:17:29 | user        |
+----+---------------------+---------------------+-------------+
2 rows in set (0.00 sec)

mysql> select * from reflections;
+----+--------------+---------------------+---------------------+
| id | principal_id | created_at          | updated_at          |
+----+--------------+---------------------+---------------------+
|  1 |            1 | 2021-11-11 11:19:01 | 2021-11-11 11:19:01 |
|  2 |            2 | 2021-11-11 11:19:01 | 2021-11-11 11:19:01 |
|  3 |            2 | 2021-11-11 11:19:01 | 2021-11-11 11:19:01 |
+----+--------------+---------------------+---------------------+
3 rows in set (0.00 sec)

mysql> select * from journal_entries;
+----+----------+--------------+---------------------+---------------------+---------------+
| id | raw_text | principal_id | created_at          | updated_at          | reflection_id |
+----+----------+--------------+---------------------+---------------------+---------------+
|  1 | je 1     |            1 | 2021-11-11 11:19:27 | 2021-11-11 11:32:25 |          NULL |
|  2 | je 2     |            1 | 2021-11-11 11:19:27 | 2021-11-11 11:32:25 |          NULL |
|  3 | je 3     |            1 | 2021-11-11 11:19:27 | 2021-11-11 11:19:27 |             1 |
|  4 | je 4     |            2 | 2021-11-11 11:19:27 | 2021-11-11 11:32:25 |          NULL |
|  5 | je 5     |            2 | 2021-11-11 11:19:27 | 2021-11-11 11:19:27 |             2 |
|  6 | je 6     |            2 | 2021-11-11 11:19:27 | 2021-11-11 11:19:27 |             3 |
+----+----------+--------------+---------------------+---------------------+---------------+
6 rows in set (0.00 sec)
```

### Run migration

```
$ flyway migrate
A new version of Flyway is available
Upgrade to Flyway 8.0.4: https://rd.gt/2X0gakb
Flyway Teams Edition 8.0.2 by Redgate
Database: jdbc:mysql://host.docker.internal:3306/rhizone_lms_development (MySQL 8.0)
----------------------------------------
Flyway Teams features are enabled by default for the next 27 days. Learn more at https://rd.gt/3A4IWym
----------------------------------------
Successfully validated 7 migrations (execution time 00:00.088s)
Current version of schema `rhizone_lms_development`: 006
Migrating schema `rhizone_lms_development` to version "007 - backfill journal entry reflections"
Successfully applied 1 migration to schema `rhizone_lms_development`, now at version v007 (execution time 00:00.220s)
```

### After

```
mysql> select * from principals;
+----+---------------------+---------------------+-------------+
| id | created_at          | updated_at          | entity_type |
+----+---------------------+---------------------+-------------+
|  1 | 2021-11-11 11:17:29 | 2021-11-11 11:17:29 | user        |
|  2 | 2021-11-11 11:17:29 | 2021-11-11 11:17:29 | user        |
+----+---------------------+---------------------+-------------+
2 rows in set (0.00 sec)

mysql> select * from reflections;
+----+--------------+---------------------+---------------------+
| id | principal_id | created_at          | updated_at          |
+----+--------------+---------------------+---------------------+
|  1 |            1 | 2021-11-11 11:19:01 | 2021-11-11 11:19:01 |
|  2 |            2 | 2021-11-11 11:19:01 | 2021-11-11 11:19:01 |
|  3 |            2 | 2021-11-11 11:19:01 | 2021-11-11 11:19:01 |
| 10 |            1 | 2021-11-11 11:39:12 | 2021-11-11 11:39:12 |
| 11 |            1 | 2021-11-11 11:39:12 | 2021-11-11 11:39:12 |
| 12 |            2 | 2021-11-11 11:39:12 | 2021-11-11 11:39:12 |
+----+--------------+---------------------+---------------------+
6 rows in set (0.00 sec)

mysql> select * from journal_entries;
+----+----------+--------------+---------------------+---------------------+---------------+
| id | raw_text | principal_id | created_at          | updated_at          | reflection_id |
+----+----------+--------------+---------------------+---------------------+---------------+
|  1 | je 1     |            1 | 2021-11-11 11:19:27 | 2021-11-11 11:39:12 |            10 |
|  2 | je 2     |            1 | 2021-11-11 11:19:27 | 2021-11-11 11:39:12 |            11 |
|  3 | je 3     |            1 | 2021-11-11 11:19:27 | 2021-11-11 11:19:27 |             1 |
|  4 | je 4     |            2 | 2021-11-11 11:19:27 | 2021-11-11 11:39:12 |            12 |
|  5 | je 5     |            2 | 2021-11-11 11:19:27 | 2021-11-11 11:19:27 |             2 |
|  6 | je 6     |            2 | 2021-11-11 11:19:27 | 2021-11-11 11:19:27 |             3 |
+----+----------+--------------+---------------------+---------------------+---------------+
6 rows in set (0.01 sec)

mysql> select table_name, column_name, is_nullable from information_schema.columns where table_name = 'journal_entries' and column_name = 'reflection_id';
+-----------------+---------------+-------------+
| TABLE_NAME      | COLUMN_NAME   | IS_NULLABLE |
+-----------------+---------------+-------------+
| journal_entries | reflection_id | NO          |
+-----------------+---------------+-------------+
1 row in set (0.00 sec)
```