### PR TITLE
Add default questionnaire for outlook check-ins

### DIFF
--- a/db/migration/V010__insert_default_questionnaire.sql
+++ b/db/migration/V010__insert_default_questionnaire.sql
@@ -1,0 +1,14 @@
+INSERT INTO questionnaires () VALUES
+  ();
+SET @questionnaire_id = LAST_INSERT_ID();
+INSERT INTO settings (property, content, category) VALUES
+  ('default_questionnaire_id', CAST(@questionnaire_id AS CHAR), 'webapp');
+INSERT INTO prompts (label, query_text, sort_order, questionnaire_id) VALUES
+  ('Outlook', 'How are you feeling about your current endeavours?', 1, @questionnaire_id);
+SET @prompt_id = LAST_INSERT_ID();
+INSERT INTO options (label, numeric_value, sort_order, prompt_id) VALUES
+  ('Very discouraged', -2, 1, @prompt_id),
+  ('A little discouraged', -1, 2, @prompt_id),
+  ('I don’t know', 0, 3, @prompt_id),
+  ('A little hopeful', 1, 4, @prompt_id),
+  ('Very hopeful', 2, 5, @prompt_id);


### PR DESCRIPTION
## Proposed changes

Add a questionnaire with prompts and options for outlook check-ins and add setting that makes it the default questionnaire. 

Resolves #104

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?

## Terminal output
```
$ flyway migrate
A new version of Flyway is available
Upgrade to Flyway 8.0.4: https://rd.gt/2X0gakb
Flyway Teams Edition 8.0.2 by Redgate
Database: jdbc:mysql://127.0.0.1/development (MySQL 8.0)
----------------------------------------
Flyway Teams features are enabled by default for the next 8 days. Learn more at https://rd.gt/3A4IWym
----------------------------------------
Successfully validated 8 migrations (execution time 00:00.095s)
Current version of schema `development`: 008
Migrating schema `development` to version "010 - insert default questionnaire"
Successfully applied 1 migration to schema `development`, now at version v010 (execution time 00:00.450s)
```
