### PR TITLE
Post to /reflections route instead of deprecated /journalentries

### DIFF
--- a/webapp/src/components/CreateJournalEntryForm.tsx
+++ b/webapp/src/components/CreateJournalEntryForm.tsx
@@ -29,7 +29,7 @@ class CreateJournalEntryForm extends Component<
   handleSubmit: FormEventHandler = async event => {
     event.preventDefault();
     const createJournalEntry = await fetch(
-      `${process.env.REACT_APP_API_ORIGIN}/journalentries`,
+      `${process.env.REACT_APP_API_ORIGIN}/reflections`,
       {
         method: 'POST',
         credentials: 'include',


### PR DESCRIPTION
## Proposed changes

Change fetch request when submitting CreateJournalEntryForm to Post to /reflections route instead of deprecated /journalentries

Resolves #62 
## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
