### PR TITLE
Post to reflections create responses

### DIFF
--- a/api/src/reflectionsRouter.test.ts
+++ b/api/src/reflectionsRouter.test.ts
@@ -44,7 +44,7 @@ function trackerHelper(done: jest.DoneCallback) {
         MOCK_OPTION_ID,
         process.env.MOCK_PRINCIPAL_ID,
         MOCK_REFLECTION_ID,
-				MOCK_OPTION_ID + 1,
+        MOCK_OPTION_ID + 1,
         process.env.MOCK_PRINCIPAL_ID,
         MOCK_REFLECTION_ID,
       ]);

--- a/api/src/reflectionsRouter.ts
+++ b/api/src/reflectionsRouter.ts
@@ -34,7 +34,6 @@ reflectionsRouter.post('/', async (req, res, next) => {
         reflection_id: insertedReflectionId[0],
       });
 
-
       if (options.length > 0) {
         await trx('responses').insert(
           options.map(option => {
@@ -46,7 +45,6 @@ reflectionsRouter.post('/', async (req, res, next) => {
           })
         );
       }
-
     });
   } catch (error) {
     next(error);


### PR DESCRIPTION
## Proposed changes

When post request is made to the `/reflections`  endpoint containing the options array they create a new entry in the response table with the associated reflection id and the provided option id from the request.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?

