### PR TITLE
Create GET /settings/:category resource

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -9,6 +9,7 @@ import { handleErrors, handleNotFound } from './errorHandlingMiddleware';
 import journalEntriesRouter from './journalEntriesRouter';
 import reflectionsRouter from './reflectionsRouter';
 import { loggedIn } from './authMiddleware';
+import settingsRouter from './settingsRouter';
 
 declare module 'express-session' {
   interface Session {
@@ -51,6 +52,8 @@ app.use('/journalentries', withCors, loggedIn, journalEntriesRouter);
 
 
 app.use('/reflections', withCors, loggedIn, reflectionsRouter);
+
+app.use('/settings', withCors, loggedIn, settingsRouter)
 
 app.get('/', (_, res) => {
   res.json({});

--- a/api/src/settingsRouter.test.ts
+++ b/api/src/settingsRouter.test.ts
@@ -1,0 +1,69 @@
+import { loginExistingUser } from './loginHelpers';
+import {
+  collectionEnvelope,
+} from './responseEnvelope';
+import { tracker } from './mockDb';
+import { InternalServerError } from './httpErrors';
+
+const responseObj = {
+  property: 'default_questionnaire_id',
+  content: '1',
+};
+
+
+const trackerHelper = (done: jest.DoneCallback, totalCount: number) => {
+  tracker.on('query', ({ bindings, sql, response }) => {
+    if (
+      sql ===
+      'select `property`, `content` from `settings` where `category` = ?'
+    ) {
+      expect(bindings).toEqual(['webapp']);
+      totalCount === 1 ? response([responseObj]) : response([responseObj, responseObj]);
+    } else if (
+      sql ===
+      'select count(*) as `total_count` from `settings` where `category` = ?'
+    ) {
+      expect(bindings).toEqual(['webapp']);
+      response([{ total_count: totalCount === 1 ? 1 : 2 }]);
+    } else {
+      done(`Unexpected sql statement. Recieved: ${sql}`);
+    }
+  });
+};
+describe('settings router', () => {
+  describe('get /settings/:category', () => {
+    it('should return the existing entry in the settings table', done => {
+      loginExistingUser(appAgent => {
+				trackerHelper(done, 1)
+        appAgent.get('/settings/webapp').expect(
+          200,
+          collectionEnvelope(
+            [
+              responseObj,
+            ],
+            1
+          ),
+          done
+        );
+      }, done);
+    });
+
+		it('should return multiple entries from the settings table', done => {
+			loginExistingUser(appAgent => {
+				trackerHelper(done, 2)
+				appAgent.get('/settings/webapp')
+				.expect(200, collectionEnvelope([responseObj, responseObj], 2), done)
+			}, done)
+		})
+    it('should catch the internal server error, and response with appropriate code', done => {
+      loginExistingUser(appAgent => {
+        tracker.on('query', ({ reject }) => {
+          reject(new InternalServerError());
+        });
+        appAgent
+          .get('/settings/webapp')
+          .expect(InternalServerError.prototype.status, done);
+      }, done);
+    });
+  });
+});

--- a/api/src/settingsRouter.ts
+++ b/api/src/settingsRouter.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+
+import { BadRequestError } from './httpErrors';
+import { collectionEnvelope, itemEnvelope } from './responseEnvelope';
+import db from './db';
+
+const settingsRouter = Router();
+
+settingsRouter.get('/:category', async (req, res, next) => {
+  const categoryName = req.params.category;
+  try {
+    const settings = await db('settings')
+      .select('property', 'content')
+      .where({ category: categoryName });
+    const countAlias = 'total_count';
+    const totalCounts = await db('settings')
+      .count({ [countAlias]: '*' })
+      .where({ category: categoryName });
+    res.json(collectionEnvelope(settings, totalCounts[0][countAlias]));
+  } catch (error) {
+    next(error);
+    return;
+  }
+});
+export default settingsRouter;

--- a/api/src/settingsRouter.ts
+++ b/api/src/settingsRouter.ts
@@ -1,7 +1,6 @@
 import { Router } from 'express';
 
-import { BadRequestError } from './httpErrors';
-import { collectionEnvelope, itemEnvelope } from './responseEnvelope';
+import { collectionEnvelope } from './responseEnvelope';
 import db from './db';
 
 const settingsRouter = Router();


### PR DESCRIPTION
## Proposed changes

Created an API endpoint at /settings/:category to retrieve all the settings for a category in the format {[property]: content} for the specified category.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
