### PR TITLE
Add netlify.toml for publishing website

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+  base = "website/"
+  publish = "public/"
+  command = "yarn build"


### PR DESCRIPTION
## Proposed changes

Declare the base and publish directories for the website in a `netlify.toml` file because the Netlify UI seems to be buggy and not using the right paths.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?

## Branch deploy

https://61a570b9cf5d330008ffae8c--opentree-education.netlify.app/