### PR TITLE
Add migration for meetings, participants, and meeting_notes tables

### DIFF
--- a/db/migration/V011__create_meetings_tables.sql
+++ b/db/migration/V011__create_meetings_tables.sql
@@ -1,0 +1,36 @@
+CREATE TABLE meetings (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  starts_at TIMESTAMP NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE participants (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  meeting_id BIGINT NOT NULL,
+  principal_id BIGINT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  INDEX participants_meeting_id (meeting_id),
+  FOREIGN KEY (meeting_id) REFERENCES meetings(id),
+  INDEX participants_principal_id (principal_id),
+  FOREIGN KEY (principal_id) REFERENCES principals(id),
+  UNIQUE (meeting_id, principal_id)
+);
+
+CREATE TABLE meeting_notes (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  note_text TEXT NOT NULL,
+  sort_order DOUBLE NOT NULL DEFAULT 0,
+  authoring_participant_id BIGINT NOT NULL,
+  agenda_owning_participant_id BIGINT,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  INDEX meeting_notes_authoring_participant_id (authoring_participant_id),
+  FOREIGN KEY (authoring_participant_id) REFERENCES participants(id),
+  INDEX meeting_notes_agenda_owning_participant_id (agenda_owning_participant_id),
+  FOREIGN KEY (agenda_owning_participant_id) REFERENCES participants(id)
+);


### PR DESCRIPTION
## Proposed changes

Adds tables based on the data representation described in the product spec.

https://docs.google.com/document/d/156DwfW14nBM2I8yAEFWOmmx4-zqX3kjzdgyuEzN5V1s/edit#heading=h.olwwi7a0ico0

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?

## Output


```
$ flyway migrate
A new version of Flyway is available
Upgrade to Flyway 8.2.0: https://rd.gt/2X0gakb
Flyway Teams Edition 8.0.2 by Redgate
Database: jdbc:mysql://host.docker.internal:3306/rhizone_lms_development (MySQL 8.0)
----------------------------------------
Flyway Teams features are enabled by default for the next 2 days. Learn more at https://rd.gt/3A4IWym
----------------------------------------
Successfully validated 13 migrations (execution time 00:00.073s)
Current version of schema `rhizone_lms_development`: 010
Migrating schema `rhizone_lms_development` to version "011 - create meetings tables"
Successfully applied 1 migration to schema `rhizone_lms_development`, now at version v011 (execution time 00:00.178s)
```

```
mysql> show tables;
+-----------------------------------+
| Tables_in_rhizone_lms_development |
+-----------------------------------+
| flyway_schema_history             |
| github_users                      |
| journal_entries                   |
| meeting_notes                     |
| meetings                          |
| options                           |
| participants                      |
| principals                        |
| prompts                           |
| questionnaires                    |
| reflections                       |
| responses                         |
| settings                          |
+-----------------------------------+
13 rows in set (0.00 sec)

mysql> describe meetings;
+------------+-----------+------+-----+-------------------+-----------------------------------------------+
| Field      | Type      | Null | Key | Default           | Extra                                         |
+------------+-----------+------+-----+-------------------+-----------------------------------------------+
| id         | bigint    | NO   | PRI | NULL              | auto_increment                                |
| starts_at  | timestamp | NO   |     | NULL              |                                               |
| created_at | timestamp | NO   |     | CURRENT_TIMESTAMP | DEFAULT_GENERATED                             |
| updated_at | timestamp | NO   |     | CURRENT_TIMESTAMP | DEFAULT_GENERATED on update CURRENT_TIMESTAMP |
+------------+-----------+------+-----+-------------------+-----------------------------------------------+
4 rows in set (0.00 sec)

mysql> describe participants;
+--------------+-----------+------+-----+-------------------+-----------------------------------------------+
| Field        | Type      | Null | Key | Default           | Extra                                         |
+--------------+-----------+------+-----+-------------------+-----------------------------------------------+
| id           | bigint    | NO   | PRI | NULL              | auto_increment                                |
| meeting_id   | bigint    | NO   | MUL | NULL              |                                               |
| principal_id | bigint    | NO   | MUL | NULL              |                                               |
| created_at   | timestamp | NO   |     | CURRENT_TIMESTAMP | DEFAULT_GENERATED                             |
| updated_at   | timestamp | NO   |     | CURRENT_TIMESTAMP | DEFAULT_GENERATED on update CURRENT_TIMESTAMP |
+--------------+-----------+------+-----+-------------------+-----------------------------------------------+
5 rows in set (0.00 sec)

mysql> describe meeting_notes;
+------------------------------+-----------+------+-----+-------------------+-----------------------------------------------+
| Field                        | Type      | Null | Key | Default           | Extra                                         |
+------------------------------+-----------+------+-----+-------------------+-----------------------------------------------+
| id                           | bigint    | NO   | PRI | NULL              | auto_increment                                |
| note_text                    | text      | NO   |     | NULL              |                                               |
| sort_order                   | double    | NO   |     | 0                 |                                               |
| authoring_participant_id     | bigint    | NO   | MUL | NULL              |                                               |
| agenda_owning_participant_id | bigint    | YES  | MUL | NULL              |                                               |
| created_at                   | timestamp | NO   |     | CURRENT_TIMESTAMP | DEFAULT_GENERATED                             |
| updated_at                   | timestamp | NO   |     | CURRENT_TIMESTAMP | DEFAULT_GENERATED on update CURRENT_TIMESTAMP |
+------------------------------+-----------+------+-----+-------------------+-----------------------------------------------+
7 rows in set (0.00 sec)
```