### PR TITLE
Add forms and thank you pages to the website

### DIFF
--- a/website/gatsby-node.js
+++ b/website/gatsby-node.js
@@ -69,6 +69,15 @@ exports.createPages = async ({ actions: { createPage }, graphql }) => {
               callToActionHref
               callToActionText
               callToActionVariant
+              formAction
+              formButtonText
+              formFields {
+                label
+                required
+                type
+              }
+              formHeading
+              formName
               heading
               headingComponent
               headingTextAlign

--- a/website/src/components/FormBuilder.tsx
+++ b/website/src/components/FormBuilder.tsx
@@ -1,0 +1,79 @@
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import FormControl from '@mui/material/FormControl';
+import { Link as GatsbyLink } from 'gatsby';
+import Paper from '@mui/material/Paper';
+import React from 'react';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+
+declare interface FormBuilderProps {
+  formAction: string;
+  formButtonText?: string;
+  formFields: {
+    label: string;
+    required?: boolean;
+    type: string;
+  }[];
+  formHeading?: string;
+  formName: string;
+}
+
+const FormBuilder = ({
+  formAction,
+  formButtonText,
+  formFields,
+  formHeading,
+  formName,
+}: FormBuilderProps) => (
+  <Paper variant="outlined">
+    <form action={formAction} data-netlify="true" method="post" name={formName}>
+      <Stack p={4} spacing={4}>
+        {formHeading && (
+          <Typography component="h2" variant="h6">
+            {formHeading}
+          </Typography>
+        )}
+        <Typography variant="body2">
+          Required fields are marked with asterisks (*).
+        </Typography>
+        {formFields.map(({ label, required = false, type }) => (
+          <FormControl fullWidth key={label}>
+            {type === 'textarea' ? (
+              <TextField
+                label={label}
+                minRows={4}
+                multiline
+                name={label}
+                required={required}
+                type="text"
+              />
+            ) : (
+              <TextField
+                label={label}
+                name={label}
+                required={required}
+                type={type}
+              />
+            )}
+          </FormControl>
+        ))}
+        <Box>
+          <p>
+            By submitting this form you agree to the{' '}
+            <GatsbyLink to="/privacy-policy/">Privacy Policy</GatsbyLink> of
+            this Site.
+          </p>
+          <p>
+            <Button type="submit" variant="contained">
+              {formButtonText || 'Submit'}
+            </Button>
+          </p>
+        </Box>
+      </Stack>
+    </form>
+  </Paper>
+);
+
+export default FormBuilder;

--- a/website/src/components/Section.tsx
+++ b/website/src/components/Section.tsx
@@ -6,6 +6,7 @@ import { Link as GatsbyLink } from 'gatsby';
 import React from 'react';
 import Typography from '@mui/material/Typography';
 
+import FormBuilder from './FormBuilder';
 import { SectionData } from '../types/content';
 
 const verticalAlignmentsMap = {
@@ -50,6 +51,11 @@ const Section = ({
               callToActionHref,
               callToActionText,
               callToActionVariant,
+              formAction,
+              formButtonText,
+              formFields = [],
+              formHeading,
+              formName,
               heading,
               headingComponent,
               headingTextAlign,
@@ -58,55 +64,68 @@ const Section = ({
               verticalWhiteSpace: columnVerticalWhiteSpace,
             },
             contentIndex
-          ) => (
-            <Grid
-              key={contentIndex}
-              item
-              md={span || 12}
-              py={
-                Number.isFinite(columnVerticalWhiteSpace)
-                  ? columnVerticalWhiteSpace
-                  : 2
-              }
-              xs={12}
-            >
-              {heading && (
-                <Typography
-                  align={headingTextAlign || 'left'}
-                  component={headingComponent || 'h2'}
-                  dangerouslySetInnerHTML={{
-                    __html: heading,
-                  }}
-                  variant={headingVariant || 'h4'}
-                  sx={{ color }}
-                />
-              )}
-              {body && (
-                <Typography
-                  align={bodyTextAlign || 'left'}
-                  component={bodyComponent || 'p'}
-                  dangerouslySetInnerHTML={{ __html: body }}
-                  mb={callToActionText && callToActionHref ? 3 : 0}
-                  mt={heading ? 2 : 0}
-                  sx={{ color }}
-                  variant={bodyVariant || 'body1'}
-                />
-              )}
-              {callToActionText && callToActionHref && (
-                <Box mt={heading || body ? 3 : 0}>
-                  <Button
-                    color={callToActionColor || 'primary'}
-                    component={GatsbyLink}
-                    size="large"
-                    to={callToActionHref}
-                    variant={callToActionVariant || 'contained'}
-                  >
-                    {callToActionText}
-                  </Button>
-                </Box>
-              )}
-            </Grid>
-          )
+          ) => {
+            const hasForm = formName && formAction && formFields.length > 0;
+            const hasCallToAction = callToActionText && callToActionHref;
+            return (
+              <Grid
+                key={contentIndex}
+                item
+                md={span || 12}
+                py={
+                  Number.isFinite(columnVerticalWhiteSpace)
+                    ? columnVerticalWhiteSpace
+                    : 2
+                }
+                xs={12}
+              >
+                {heading && (
+                  <Typography
+                    align={headingTextAlign || 'left'}
+                    component={headingComponent || 'h2'}
+                    dangerouslySetInnerHTML={{
+                      __html: heading,
+                    }}
+                    variant={headingVariant || 'h4'}
+                    sx={{ color }}
+                  />
+                )}
+                {body && (
+                  <Typography
+                    align={bodyTextAlign || 'left'}
+                    component={bodyComponent || 'p'}
+                    dangerouslySetInnerHTML={{ __html: body }}
+                    mb={hasCallToAction || hasForm ? 3 : 0}
+                    mt={heading ? 2 : 0}
+                    sx={{ color }}
+                    variant={bodyVariant || 'body1'}
+                  />
+                )}
+                {hasCallToAction && (
+                  <Box mt={heading || body ? 3 : 0}>
+                    <Button
+                      color={callToActionColor || 'primary'}
+                      component={GatsbyLink}
+                      size="large"
+                      to={callToActionHref}
+                      variant={callToActionVariant || 'contained'}
+                    >
+                      {callToActionText}
+                    </Button>
+                  </Box>
+                )}
+                {hasForm && (
+                  <FormBuilder
+                    formAction={formAction}
+                    formButtonText={formButtonText}
+                    formFields={formFields}
+                    formHeading={formHeading}
+                    formName={formName}
+                  />
+                )}
+              </Grid>
+            );
+          }
         )}
       </Grid>
     </Container>

--- a/website/src/content/pages/contact-thanks.yml
+++ b/website/src/content/pages/contact-thanks.yml
@@ -1,0 +1,9 @@
+title: Thanks for Contacting OpenTree Education
+sections:
+  - columns:
+      - heading: Thanks for the message!
+        headingVariant: h2
+        body: |
+          We’ve received your message and will respond to you by email.
+        callToActionText: Go back to home page
+        callToActionHref: '/'

--- a/website/src/content/pages/contact.yml
+++ b/website/src/content/pages/contact.yml
@@ -30,7 +30,22 @@ sections:
       - heading: Send a message
         body: |
           We’re more than happy to chat about anything related to equitable education and employement. Use this form if you have any questions about our programs or this website, too.
-        span: 8
+        formName: Contact
+        formAction: /contact-thanks/
+        formHeading: Contact OpenTree Education
+        formButtonText: Send message
+        formFields:
+          - label: Your name
+            type: text
+            required: true
+          - label: Email address
+            type: email
+            required: true
+          - label: Write a message
+            type: textarea
+            required: true
+        span: 6
+      - span: 2
       - heading: Mailing address
         body: |
           <p>OpenTree Education Inc. is registered in British Columbia, Canada. You can use this address when required to mail materials to us.</p>

--- a/website/src/content/pages/employers-thanks.yml
+++ b/website/src/content/pages/employers-thanks.yml
@@ -1,0 +1,9 @@
+title: OpenTree Education Employer Partner Application Received
+sections:
+  - columns:
+      - heading: Application Received
+        headingVariant: h2
+        body: |
+          We’ll be reaching out by email to talk to you about the next steps in hiring from us. Looking forward to speaking with you!
+        callToActionText: Go back to home page
+        callToActionHref: '/'

--- a/website/src/content/pages/employers.yml
+++ b/website/src/content/pages/employers.yml
@@ -77,4 +77,24 @@ sections:
     columns:
       - heading: Apply to be an employer partner
         body: |
-          Application form goes here.
+          We’re interested in talking to companies of all sizes and shapes. If you hire software developers and care about diveristy, equity, and inclusion, then we will work with you to secure exceptional talent.
+        span: 4
+      - span: 1
+      - span: 7
+        formName: Employers
+        formAction: /employers-thanks/
+        formHeading: Employer partnership application
+        formButtonText: Submit application
+        formFields:
+          - label: Your name
+            type: text
+            required: true
+          - label: Email address
+            type: email
+            required: true
+          - label: Company name
+            type: text
+            required: true
+          - label: Your role
+            type: text
+            required: true

--- a/website/src/content/pages/professional-mentorship-program-thanks.yml
+++ b/website/src/content/pages/professional-mentorship-program-thanks.yml
@@ -1,0 +1,9 @@
+title: OpenTree Education Professional Mentorship Program Application Received
+sections:
+  - columns:
+      - heading: Application Received
+        headingVariant: h2
+        body: |
+          We’ll be reaching out by email to talk to you about the next steps the application process. Looking forward to speaking with you!
+        callToActionText: Go back to home page
+        callToActionHref: '/'

--- a/website/src/content/pages/professional-mentorship-program.yml
+++ b/website/src/content/pages/professional-mentorship-program.yml
@@ -91,4 +91,26 @@ sections:
     columns:
       - heading: Apply to the OpenTree Education Professional Mentorship Program
         body: |
-          Application form goes here.
+          Filling out this form is the first step to getting a placement in the program. Once we review your application, we’ll send you an email to set up the next steps.
+        span: 4
+      - span: 1
+      - span: 7
+        formName: Professional Mentorship Program
+        formAction: /professional-mentorship-program-thanks/
+        formHeading: Professional Mentorship Program application
+        formButtonText: Submit application
+        formFields:
+          - label: Your name
+            type: text
+            required: true
+          - label: Email address
+            type: email
+            required: true
+          - label: Where are you located?
+            type: text
+          - label: Describe your work and educational background
+            type: textarea
+          - label: What do you do during your days?
+            type: textarea
+          - label: What are your goals?
+            type: textarea

--- a/website/src/types/content.d.ts
+++ b/website/src/types/content.d.ts
@@ -17,6 +17,15 @@ export interface ColumnData {
   callToActionHref?: string;
   callToActionText?: string;
   callToActionVariant?: 'text' | 'outlined' | 'contained';
+  formAction?: string;
+  formButtonText?: string;
+  formFields?: {
+    label: string;
+    required?: boolean;
+    type: 'text' | 'email' | 'textarea';
+  }[];
+  formHeading?: string;
+  formName?: string;
   heading?: string;
   headingComponent?: ElementType;
   headingTextAlign?: 'left' | 'center' | 'right';


### PR DESCRIPTION
## Proposed changes

Enables forms to be added to pages on the website by adding the appropriate fields on columns in page yaml.

Adds application forms for the program and employers, and a contact form on the contact page. Adds thank you pages that forms will redirect to after submission.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
