### PR TITLE
Remove trailing slash from form actions to prevent redirect

### DIFF
--- a/website/src/content/pages/contact.yml
+++ b/website/src/content/pages/contact.yml
@@ -31,7 +31,7 @@ sections:
         body: |
           We’re more than happy to chat about anything related to equitable education and employement. Use this form if you have any questions about our programs or this website, too.
         formName: Contact
-        formAction: /contact-thanks/
+        formAction: /contact-thanks
         formHeading: Contact OpenTree Education
         formButtonText: Send message
         formFields:

--- a/website/src/content/pages/employers.yml
+++ b/website/src/content/pages/employers.yml
@@ -82,7 +82,7 @@ sections:
       - span: 1
       - span: 7
         formName: Employers
-        formAction: /employers-thanks/
+        formAction: /employers-thanks
         formHeading: Employer partnership application
         formButtonText: Submit application
         formFields:

--- a/website/src/content/pages/professional-mentorship-program.yml
+++ b/website/src/content/pages/professional-mentorship-program.yml
@@ -96,7 +96,7 @@ sections:
       - span: 1
       - span: 7
         formName: Professional Mentorship Program
-        formAction: /professional-mentorship-program-thanks/
+        formAction: /professional-mentorship-program-thanks
         formHeading: Professional Mentorship Program application
         formButtonText: Submit application
         formFields:


### PR DESCRIPTION
## Proposed changes

The thank you pages were redirecting from having a trailing slash to having no slash. This might be affecting whether the forms can submit, so this is an experiment to see if it fixes the issue. That said, it has to be deployed to test it out.

Inferred from https://docs.netlify.com/forms/setup/#success-messages

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
