### PR TITLE
Add user resource for getting current session principal id

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -12,6 +12,7 @@ import meetingsRouter from './meetingsRouter';
 import questionnairesRouter from './questionnairesRouter';
 import reflectionsRouter from './reflectionsRouter';
 import settingsRouter from './settingsRouter';
+import userRouter from './userRouter';
 
 declare module 'express-session' {
   interface Session {
@@ -49,6 +50,8 @@ app.use(
 const withCors = cors({ credentials: true, origin: process.env.WEBAPP_ORIGIN });
 
 app.use(withCors, authRouter);
+
+app.use('/user', withCors, userRouter);
 
 app.use('/journalentries', withCors, loggedIn, journalEntriesRouter);
 

--- a/api/src/userRouter.test.ts
+++ b/api/src/userRouter.test.ts
@@ -1,0 +1,26 @@
+import { itemEnvelope } from './responseEnvelope';
+import { loginExistingUser } from './loginHelpers';
+import app from './app';
+import { agent } from 'supertest';
+
+describe('userRouter', () => {
+  describe('GET /user', () => {
+    it('should return an anonymous user object for an unauthenticated session', done => {
+      agent(app)
+        .get('/user')
+        .expect(200, itemEnvelope({ principal_id: null }), done);
+    });
+
+    it('should return a user object with the right principal id for an authenticated session', done => {
+      loginExistingUser(appAgent => {
+        appAgent
+          .get('/user')
+          .expect(
+            200,
+            itemEnvelope({ principal_id: process.env.MOCK_PRINCIPAL_ID }),
+            done
+          );
+      }, done);
+    });
+  });
+});

--- a/api/src/userRouter.ts
+++ b/api/src/userRouter.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { itemEnvelope } from './responseEnvelope';
+
+const userRouter = Router();
+
+userRouter.get('/', (req, res) => {
+  const { principalId } = req.session;
+  res.json(itemEnvelope({ principal_id: principalId || null }));
+});
+
+export default userRouter;


### PR DESCRIPTION
## Proposed changes

Adds a singular `/user` resource that represents the currently logged in user. A non-logged in user is an anonymous user with a `null` principal id. 

Resolves #195.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
