### PR TITLE
Redirect www to no-www on website

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -1,0 +1,1 @@
+https://www.opentree.education/* https://opentree.education/:splat 301!


### PR DESCRIPTION
## Proposed changes

Ensure that requests for www.opentree.education are redirected to opentree.education using Netlify redirect rules.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
