### PR TITLE
Add force trailing slashes plugin for website

### DIFF
--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -36,5 +36,11 @@ module.exports = {
       },
       __key: 'content',
     },
+    {
+      resolve: 'gatsby-plugin-force-trailing-slashes',
+      options: {
+        excludedPaths: [`/404.html`],
+      },
+    },
   ],
 };

--- a/website/package.json
+++ b/website/package.json
@@ -28,6 +28,7 @@
     "eslint-config-react-app": "^6.0.0",
     "gatsby": "^4.2.0",
     "gatsby-image": "^3.11.0",
+    "gatsby-plugin-force-trailing-slashes": "^1.0.5",
     "gatsby-plugin-google-analytics": "^4.2.0",
     "gatsby-plugin-image": "^2.3.0",
     "gatsby-plugin-manifest": "^4.2.0",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1125,6 +1125,13 @@
     core-js-pure "^3.19.0"
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.10.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.6", "@babel/runtime@^7.14.8", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
@@ -7682,6 +7689,13 @@ gatsby-page-utils@^2.2.0:
     glob "^7.2.0"
     lodash "^4.17.21"
     micromatch "^4.0.4"
+
+gatsby-plugin-force-trailing-slashes@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-force-trailing-slashes/-/gatsby-plugin-force-trailing-slashes-1.0.5.tgz#22d2f16bf4dea4fca79c129cf9cbd29d9229d888"
+  integrity sha512-RxRdW++bvSHv4Mho999W0LLNdiQX1OMOvY0v1TlafcaYqJ93fYV/Jp3DDD6PKS0PAKNS8Q8DRsD67cipFmZCFA==
+  dependencies:
+    "@babel/runtime" "7.12.5"
 
 gatsby-plugin-google-analytics@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
## Proposed changes

Add a plugin that prevents the url from flashing between a version with and without a slash for pages on the website.

Resolves #221.