### PR TITLE
New Gatsby image component doesn't support fadeIn, so use plain img

### DIFF
--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -61,13 +61,12 @@ const Header = () => (
                 src={opentreeEducationLogo}
                 width={38}
               />
-              <ImgixGatsbyImage
+              <img
+                width="100"
+                height="36"
+                src="https://opentree-education.imgix.net/opentree-education.png?fit=min&amp;q=75&amp;w=100&amp;h=36"
+                srcSet="https://opentree-education.imgix.net/opentree-education.png?fit=min&amp;q=75&amp;w=100&amp;h=36, https://opentree-education.imgix.net/opentree-education.png?fit=min&amp;q=50&amp;w=200&amp;h=72 2x"
                 alt="OpenTree Education"
-                src="https://opentree-education.imgix.net/opentree-education.png"
-                layout="fixed"
-                width={100}
-                sourceHeight={547}
-                sourceWidth={1500}
               />
             </Stack>
           </GatsbyLink>


### PR DESCRIPTION
## Proposed changes

Use a plain image tag for the word mark on the website so that it loads eagerly and doesn't fade in.

Resolves #225.