### PR TITLE
Revert "Store api session data in the database"

### DIFF
--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -33,6 +33,10 @@ jobs:
         if: always()
         working-directory: api
         run: yarn eslint 'src/**/*.ts'
+      - name: Run API tests
+        if: always()
+        working-directory: api
+        run: yarn jest --passWithNoTests
 
       - name: Install web app dependencies
         if: always()

--- a/README.md
+++ b/README.md
@@ -112,21 +112,6 @@ ESLint and Prettier can automatically fix many mistakes that will cause
 automated checks to fail. It is recommended to use the preconfigured
 `yarn delint` command before committing to a module that supports it.
 
-### Developing a database migration
-
-Database migrations run automatically when `docker-compose up` is run. However,
-while developing a migration, it is sometimes required to run Flyway commands
-manually. Those commands can be run with Docker Compose to inherit the
-configuration from `docker-compose.yml`. For example, to print info on the
-status of migrations, run:
-
-```
-docker-compose run flyway info
-```
-
-For more commands, see the
-[Flyway CLI docs](https://flywaydb.org/documentation/usage/commandline/).
-
 ## Modules
 
 ### `/api`

--- a/api/package.json
+++ b/api/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "body-parser": "^1.19.0",
-    "connect-session-knex": "^2.1.1",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-session": "^1.17.2",

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,12 +1,10 @@
 import bodyParser from 'body-parser';
-import connectSessionKnex from 'connect-session-knex';
 import cors from 'cors';
 import express from 'express';
 import helmet from 'helmet';
 import session from 'express-session';
 
 import authRouter from './authRouter';
-import db from './db';
 import { handleErrors, handleNotFound } from './errorHandlingMiddleware';
 import journalEntriesRouter from './journalEntriesRouter';
 import { loggedIn } from './authMiddleware';
@@ -36,21 +34,16 @@ app.use(bodyParser.json());
 
 app.set('trust proxy', 1);
 
-const KnexSessionStore = connectSessionKnex(session);
 app.use(
   session({
+    secret: process.env.SESSION_SECRET || 'default session secret',
+    name: 'session_id',
+    resave: true,
+    saveUninitialized: true,
     cookie: {
       sameSite: true,
       secure: app.get('secure'),
     },
-    name: 'session_id',
-    resave: true,
-    secret: process.env.SESSION_SECRET || 'default session secret',
-    saveUninitialized: true,
-    store: new KnexSessionStore({
-      createtable: false,
-      knex: db,
-    }),
   })
 );
 

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1104,7 +1104,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bluebird@^3.4.1, bluebird@^3.7.2:
+bluebird@^3.4.1:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -1347,11 +1347,6 @@ colorette@1.2.1:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
   integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
 
-colorette@2.0.16:
-  version "2.0.16"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
-  integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
-
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -1385,14 +1380,6 @@ configstore@^5.0.1:
     unique-string "^2.0.0"
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
-
-connect-session-knex@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/connect-session-knex/-/connect-session-knex-2.1.1.tgz#3543417a0c2bb6700b219e3c88f4e1b4b304f09a"
-  integrity sha512-gIOqwoU4mWe9uwkWsnBI9KsBr2sYp0IyXX6NJG7oGW6wJjy5CpWufB3FoJPEYb2OqNPMmshr07vS12pcMfok2g==
-  dependencies:
-    bluebird "^3.7.2"
-    knex "^0.95.6"
 
 content-disposition@0.5.3:
   version "0.5.3"
@@ -3019,25 +3006,6 @@ knex@^0.95.11:
   integrity sha512-grDetD91O8VoQVCFqeWTgkzdq5406W6rggF/lK1hHuwzmjDs/0m9KxyncGdZbklTi7aUgHvw3+Cfy4x7FvpdaQ==
   dependencies:
     colorette "1.2.1"
-    commander "^7.1.0"
-    debug "4.3.2"
-    escalade "^3.1.1"
-    esm "^3.2.25"
-    getopts "2.2.5"
-    interpret "^2.2.0"
-    lodash "^4.17.21"
-    pg-connection-string "2.5.0"
-    rechoir "0.7.0"
-    resolve-from "^5.0.0"
-    tarn "^3.0.1"
-    tildify "2.0.0"
-
-knex@^0.95.6:
-  version "0.95.15"
-  resolved "https://registry.yarnpkg.com/knex/-/knex-0.95.15.tgz#39d7e7110a6e2ad7de5d673d2dea94143015e0e7"
-  integrity sha512-Loq6WgHaWlmL2bfZGWPsy4l8xw4pOE+tmLGkPG0auBppxpI0UcK+GYCycJcqz9W54f2LiGewkCVLBm3Wq4ur/w==
-  dependencies:
-    colorette "2.0.16"
     commander "^7.1.0"
     debug "4.3.2"
     escalade "^3.1.1"

--- a/db/migration/V012__create_sessions_table.sql
+++ b/db/migration/V012__create_sessions_table.sql
@@ -1,7 +1,0 @@
-CREATE TABLE sessions (
-  sid VARCHAR(255) NOT NULL,
-  sess JSON NOT NULL,
-  expired DATETIME NOT NULL,
-  PRIMARY KEY (sid),
-  INDEX sessions_expired_index (expired)
-);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - MYSQL_USER=dev
     volumes:
       - ./api:/app
-      - api_node_modules:/app/node_modules
+      - /app/node_modules
   db:
     command: --default-authentication-plugin=mysql_native_password
     environment:
@@ -52,7 +52,4 @@ services:
       - REACT_APP_API_ORIGIN=http://api.rhi.zone-development
     volumes:
       - ./webapp:/app
-      - webapp_node_modules:/app/node_modules
-volumes:
-  api_node_modules:
-  webapp_node_modules:
+      - /app/node_modules


### PR DESCRIPTION
Reverts OpenTree-Education/rhizone-lms#236

Gonna use Redis instead. Production couldn't compile because of this library, and it looks like it's not very robust, given the kinds of issues that are open for it.