### PR TITLE
Replace body-parser with express built-in json parser

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -18,7 +18,6 @@
     "test:watch": "jest --watchAll"
   },
   "dependencies": {
-    "body-parser": "^1.19.0",
     "connect-redis": "^6.0.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1,5 +1,4 @@
 // istanbul ignore file
-import bodyParser from 'body-parser';
 import connectRedis from 'connect-redis';
 import cors from 'cors';
 import { createClient as createRedisClient } from 'redis';
@@ -42,7 +41,7 @@ const start = async () => {
   app.set('trust proxy', 1);
 
   app.use(helmet());
-  app.use(bodyParser.json());
+  app.use(express.json());
 
   const RedisStore = connectRedis(expressSession);
   const redisClient = createRedisClient({ host: 'redis' });

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1327,7 +1327,7 @@ bluebird@^3.4.1:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-body-parser@1.19.0, body-parser@^1.19.0:
+body-parser@1.19.0:
   version "1.19.0"
   resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==


### PR DESCRIPTION
## Proposed changes

Removes body-parser dependency and replaces it with the built-in json parser in express.

Resolves #161.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
