### PR TITLE
Ensure auth callback exits appropriately in github api error states

### DIFF
--- a/api/src/middleware/__tests__/authRouter.ts
+++ b/api/src/middleware/__tests__/authRouter.ts
@@ -68,7 +68,7 @@ describe('authRouter', () => {
   });
 
   describe('GET /auth/github/callback', () => {
-    it('should respond to requests without a code in the query string with Bad Request', done => {
+    it('should respond with a bad request error to requests without a code in the query string', done => {
       appAgent.get('/auth/github/callback').expect(400, done);
     });
 

--- a/api/src/middleware/authRouter.ts
+++ b/api/src/middleware/authRouter.ts
@@ -9,6 +9,7 @@ import {
   getGithubUser,
 } from '../services/githubApiService';
 import { itemEnvelope } from './responseEnvelope';
+import { BadRequestError } from './httpErrors';
 
 const authRouter = Router();
 
@@ -33,7 +34,7 @@ authRouter.get('/auth/github/login', (req, res) => {
 authRouter.get(`/auth/github/callback`, async (req, res, next) => {
   const { code } = req.query;
   if (!code) {
-    res.sendStatus(400);
+    next(new BadRequestError('A "code" query string parameter is required.'));
     return;
   }
   let accessToken;

--- a/api/src/services/__tests__/githubApiService.ts
+++ b/api/src/services/__tests__/githubApiService.ts
@@ -19,6 +19,13 @@ describe('githubApiService', () => {
         `https://github.com/login/oauth/access_token?client_id=undefined&client_secret=undefined&code=${code}`
       );
     });
+
+    it('throws an error if the response from github described an error response', async () => {
+      mockRequestPost.mockResolvedValue({
+        body: { error: 'bad_verification_code' },
+      } as Response);
+      await expect(getGithubAccessToken('bad_code')).rejects.toThrow();
+    });
   });
 
   describe('getGithubUser', () => {

--- a/api/src/services/githubApiService.ts
+++ b/api/src/services/githubApiService.ts
@@ -8,6 +8,9 @@ export const getGithubAccessToken = async (code: string) => {
   const response = await request.post(
     `https://github.com/login/oauth/access_token?${params.toString()}`
   );
+  if (response.body.error) {
+    throw new Error(response.body.error);
+  }
   return response.body.access_token;
 };
 


### PR DESCRIPTION
## Proposed changes

Use the new httpErrors module for auth/github/callback validation error.

Throw an error when requesting an access token from github fails. The response status is 200, but the body has an error property.

Resolves #78.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
