### PR TITLE
Always add latest tag in the workflow because it only runs on main

### DIFF
--- a/.github/workflows/build_and_publish_images.yml
+++ b/.github/workflows/build_and_publish_images.yml
@@ -31,7 +31,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}_api
           tags: |
             type=sha
-            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=raw,value=latest
       - name: Build and push api image
         uses: docker/build-push-action@v2
         with:
@@ -62,7 +62,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}_nginx
           tags: |
             type=sha
-            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=raw,value=latest
       - name: Build and push nginx image
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
## Proposed changes

Since the workflow runs on release, and only the main branch is released, the workflow can just add the latest tag by default without a condition.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
