### PR TITLE
Use Docker DNS name for api from nginx

### DIFF
--- a/nginx/production/nginx.conf
+++ b/nginx/production/nginx.conf
@@ -54,7 +54,7 @@ http {
     }
 
     upstream rhizone_lms_api {
-        server localhost:8491;
+        server api:8491;
     }
 
     server {


### PR DESCRIPTION
## Proposed changes

Since Nginx and the API aren't both running on localhost anymore, nginx needs to resolve the IP address of the api to forward requests.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
