### PR TITLE
Create Entity and EntityId types in webapp

### DIFF
--- a/webapp/src/components/CreateReflectionForm.tsx
+++ b/webapp/src/components/CreateReflectionForm.tsx
@@ -2,11 +2,12 @@ import { Alert, Card, CardContent, Snackbar, TextField } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
 import React, { FormEventHandler, useContext, useState } from 'react';
 
+import { EntityId } from '../types/api';
 import SettingsContext from './SettingsContext';
 import Questionnaire from './Questionnaire';
 
 interface CreateReflectionFormProps {
-  onReflectionCreated?: (id: number) => void;
+  onReflectionCreated?: (id: EntityId) => void;
 }
 
 const CreateReflectionForm = ({
@@ -20,7 +21,7 @@ const CreateReflectionForm = ({
   const [journalEntryText, setJournalEntryText] = useState('');
   const [journalEntryTextRows, setJournalEntryTextRows] = useState(1);
   const [selectedOptionIds, setSelectedOptionIds] = useState(
-    new Map<number, number>()
+    new Map<EntityId, EntityId>()
   );
   const onSubmit: FormEventHandler = event => {
     event.preventDefault();

--- a/webapp/src/components/Meeting.tsx
+++ b/webapp/src/components/Meeting.tsx
@@ -1,12 +1,12 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { Grid } from '@mui/material';
 
+import { EntityId, Meeting as APIMeeting } from '../types/api';
 import { formatDate, formatTime } from '../helpers/dateTime';
-import { Meeting as APIMeeting } from '../types/api';
 import SessionContext from './SessionContext';
 
 interface MeetingProps {
-  meetingId?: number | string;
+  meetingId?: EntityId;
 }
 
 const Meeting = ({ meetingId }: MeetingProps) => {

--- a/webapp/src/components/Questionnaire.tsx
+++ b/webapp/src/components/Questionnaire.tsx
@@ -7,12 +7,12 @@ import {
 } from '@mui/material';
 import React, { Fragment, useEffect, useState } from 'react';
 
-import { Questionnaire as APIQuestionnaire } from '../types/api';
+import { EntityId, Questionnaire as APIQuestionnaire } from '../types/api';
 
 declare interface QuestionnaireProps {
-  onChange?: (selectedOptionIds: Map<number, number>) => void;
-  questionnaireId: number | string;
-  selectedOptionIds: Map<number, number>;
+  onChange?: (selectedOptionIds: Map<EntityId, EntityId>) => void;
+  questionnaireId: EntityId;
+  selectedOptionIds: Map<EntityId, EntityId>;
 }
 
 const Questionnaire = ({

--- a/webapp/src/components/ReflectionsPage.tsx
+++ b/webapp/src/components/ReflectionsPage.tsx
@@ -2,7 +2,7 @@ import { Box, Grid, Stack } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 
 import CreateReflectionForm from './CreateReflectionForm';
-import { Reflection } from '../types/api';
+import { EntityId, Reflection } from '../types/api';
 import ReflectionCard from './ReflectionCard';
 
 const ReflectionsPage = () => {
@@ -10,7 +10,7 @@ const ReflectionsPage = () => {
   const [isLoadingReflections, setIsLoadingReflections] = useState(false);
   const [reflections, setReflections] = useState<Reflection[]>([]);
   const [newlyCreatedReflectionIds, setNewlyCreatedReflectionIds] = useState<
-    number[]
+    EntityId[]
   >([]);
   useEffect(() => {
     setIsLoadingReflections(true);

--- a/webapp/src/components/SessionContext.ts
+++ b/webapp/src/components/SessionContext.ts
@@ -2,7 +2,7 @@ import { createContext } from 'react';
 
 import { SessionData } from '../types/api';
 
-const anonymousSession = { principal_id: null };
+const anonymousSession = { id: null, principal_id: null };
 
 const SessionContext = createContext<SessionData>(anonymousSession);
 

--- a/webapp/src/components/SettingsContext.ts
+++ b/webapp/src/components/SettingsContext.ts
@@ -3,6 +3,7 @@ import { createContext } from 'react';
 import { Settings } from '../types/api';
 
 export const defaultSettings = {
+  id: null,
   default_questionnaire_id: '',
 };
 

--- a/webapp/src/types/api.d.ts
+++ b/webapp/src/types/api.d.ts
@@ -1,67 +1,63 @@
-export interface CreationResponseEnvelope {
-  data: {
-    id: number;
-  };
+export type EntityId = number | string | null | undefined;
+
+export interface Entity {
+  id: EntityId;
 }
 
-export interface Prompt {
-  id: number;
+export interface CreationResponseEnvelope {
+  data: Entity;
+}
+
+export interface Prompt extends Entity {
   label: string;
   options: Option[];
   query_text: string;
 }
 
-export interface Option {
-  id: number;
+export interface Option extends Entity {
   label: string;
   prompt: Prompt;
 }
 
-export interface Questionnaire {
+export interface Questionnaire extends Entity {
   prompts: Prompt[];
 }
 
-export interface Response {
-  id: number;
+export interface Response extends Entity {
   option: Option;
 }
 
-export interface JournalEntry {
-  id: number;
+export interface JournalEntry extends Entity {
   raw_text: string;
 }
 
-export interface Reflection {
-  id: number;
+export interface Reflection extends Entity {
   created_at: string;
   journal_entries: JournalEntry[];
   responses: Response[];
 }
 
-export interface Participant {
-  id: number;
-  principal_id: number;
+export interface Participant extends Entity {
+  principal_id: EntityId;
 }
 
-export interface Meeting {
-  id: number;
+export interface Meeting extends Entity {
   starts_at: string;
   participants: Participant[];
   meeting_notes: MeetingNote[];
 }
 
-export interface MeetingNote {
-  id: number;
+export interface MeetingNote extends Entity {
   note_text: string;
   sort_order: number;
-  authoring_participant_id: number;
-  agenda_owning_participant_id: number | null;
+  authoring_participant_id: EntityId;
+  agenda_owning_participant_id: EntityId;
 }
 
-export interface SessionData {
-  principal_id: number | null;
+export interface SessionData extends Entity {
+  principal_id: EntityId;
 }
 
-export interface Settings {
-  default_questionnaire_id: string;
+export interface Settings extends Entity {
+  default_questionnaire_id: EntityId;
 }


### PR DESCRIPTION
## Proposed changes

Creates new `Entity` and `EntityId` types in `webapp` to enforce consistent use of ids in data types from the API.

Resolves #184.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
