### PR TITLE
Decouple state from behaviour in journal entry creation form

### DIFF
--- a/webapp/src/components/CreateReflectionForm.tsx
+++ b/webapp/src/components/CreateReflectionForm.tsx
@@ -19,7 +19,8 @@ const CreateReflectionForm = ({
   const [saveReflectionError, setSaveReflectionError] = useState(null);
   const [isSuccessMessageVisible, setIsSuccessMessageVisible] = useState(false);
   const [journalEntryText, setJournalEntryText] = useState('');
-  const [journalEntryTextRows, setJournalEntryTextRows] = useState(1);
+  const [wasJournalEntryTextTouched, setWasJournalEntryTextTouched] =
+    useState(false);
   const [selectedOptionIds, setSelectedOptionIds] = useState(
     new Map<EntityId, EntityId>()
   );
@@ -74,8 +75,8 @@ const CreateReflectionForm = ({
           <TextField
             fullWidth
             label="How is it going?"
-            onFocus={() => setJournalEntryTextRows(4)}
-            minRows={journalEntryTextRows}
+            onFocus={() => setWasJournalEntryTextTouched(true)}
+            minRows={wasJournalEntryTextTouched ? 4 : 1}
             multiline
             onChange={event => setJournalEntryText(event.target.value)}
             value={journalEntryText}


### PR DESCRIPTION
## Proposed changes

Instead of having state that stores presentational data, store only the relevant UI state and use that for behaviour.

Resolves #180.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
