### PR TITLE
Remove "OpenTree Education" from welcome page

### DIFF
--- a/webapp/src/components/LoginPage.tsx
+++ b/webapp/src/components/LoginPage.tsx
@@ -5,9 +5,7 @@ const LoginPage = () => (
   <Container fixed sx={{ pt: 12 }}>
     <Stack alignItems="center">
       <h1>Rhizone</h1>
-      <Typography variant="subtitle1">
-        The OpenTree Education Learning Management System
-      </Typography>
+      <Typography variant="subtitle1">Learning Management System</Typography>
       <Box my={12}>
         <Button
           component="a"


### PR DESCRIPTION
## Proposed changes

Removes "OpenTree Education" from the welcome page of the app. As an open source project, it makes sense for this product to be "white label", although the copyright notice must continue to refer to OpenTree Education Inc.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
