### PR TITLE
Add competencies services and test 

### DIFF
--- a/api/src/services/__tests__/competenciesService.ts
+++ b/api/src/services/__tests__/competenciesService.ts
@@ -2,18 +2,21 @@ import { listCompetencies } from '../competenciesService';
 import { mockQuery } from '../mockDb';
 
 describe('listCompetencies', () => {
-  it('should load a page that lists the competencies in the database with their titles and descriptions.', async () => {
+  it('should query the lists of the competencies in the database with their titles and descriptions.', async () => {
+    const competencies = [
+      {
+        id: 2,
+        label: 'label',
+        description: 'description',
+      },
+    ];
+    const limit = 3;
+    const offset = 4;
     mockQuery(
       'select `id`, `label`, `description` from `competencies` limit ? offset ?',
-      [10, 10],
-      [{ id: 1, label: 'Code', description: 'To code or not to code...' }]
+      [limit, offset],
+      competencies
     );
-    expect(await listCompetencies(10, 10)).toEqual([
-      {
-        id: 1,
-        label: 'Code',
-        description: 'To code or not to code...',
-      },
-    ]);
+    expect(await listCompetencies(limit, offset)).toEqual(competencies);
   });
 });

--- a/api/src/services/__tests__/competenciesService.ts
+++ b/api/src/services/__tests__/competenciesService.ts
@@ -1,0 +1,19 @@
+import { listCompetencies } from '../competenciesService';
+import { mockQuery } from '../mockDb';
+
+describe('listCompetencies', () => {
+  it('should load a page that lists the competencies in the database with their titles and descriptions.', async () => {
+    mockQuery(
+      'select `id`, `label`, `description` from `competencies` limit ? offset ?',
+      [10, 10],
+      [{ id: 1, label: 'Code', description: 'To code or not to code...' }]
+    );
+    expect(await listCompetencies(10, 10)).toEqual([
+      {
+        id: 1,
+        label: 'Code',
+        description: 'To code or not to code...',
+      },
+    ]);
+  });
+});

--- a/api/src/services/__tests__/competenciesService.ts
+++ b/api/src/services/__tests__/competenciesService.ts
@@ -1,22 +1,24 @@
 import { listCompetencies } from '../competenciesService';
 import { mockQuery } from '../mockDb';
 
-describe('listCompetencies', () => {
-  it('should query the lists of the competencies in the database with their titles and descriptions.', async () => {
-    const competencies = [
-      {
-        id: 2,
-        label: 'label',
-        description: 'description',
-      },
-    ];
-    const limit = 3;
-    const offset = 4;
-    mockQuery(
-      'select `id`, `label`, `description` from `competencies` limit ? offset ?',
-      [limit, offset],
-      competencies
-    );
-    expect(await listCompetencies(limit, offset)).toEqual(competencies);
+describe('competenciesService', () => {
+  describe('listCompetencies', () => {
+    it('should query the lists of the competencies in the database with their labels and descriptions', async () => {
+      const competencies = [
+        {
+          id: 2,
+          label: 'label',
+          description: 'description',
+        },
+      ];
+      const limit = 3;
+      const offset = 4;
+      mockQuery(
+        'select `id`, `label`, `description` from `competencies` limit ? offset ?',
+        [limit, offset],
+        competencies
+      );
+      expect(await listCompetencies(limit, offset)).toEqual(competencies);
+    });
   });
 });

--- a/api/src/services/competenciesService.ts
+++ b/api/src/services/competenciesService.ts
@@ -1,0 +1,10 @@
+import db from './db';
+
+export const listCompetencies = async (limit: number, offset: number) => {
+  const competencies = await db('competencies')
+    .select('id', 'label', 'description')
+    .limit(limit)
+    .offset(offset);
+
+  return competencies;
+};


### PR DESCRIPTION
## Proposed changes

This change creates a competencies service function and tests to fetch competencies list with pagination. 

This is the 1st PR covering the query portion. for ticket #272 

## Checklist

- [X] Are the issues being addressed linked to this PR?
- [X] Do all commit messages start with the issue number?
- [X] Are all code changes sufficiently tested?
- [X] Are there screenshots for UI changes?
