### PR TITLE
Add api to fetch competencies

### DIFF
--- a/api/src/middleware/__tests__/competenciesRouter.ts
+++ b/api/src/middleware/__tests__/competenciesRouter.ts
@@ -39,7 +39,14 @@ describe('competenciesRouter', () => {
         );
     });
 
+    it('should respond with an internal server error if an error was thrown while counting competencies', done => {
+      mockCountCompetencies.mockRejectedValue(new Error());
+      mockListCompetencies.mockResolvedValue([]);
+      appAgent.get('/').expect(500, done);
+    });
+
     it('should respond with an internal server error if an error was thrown while listing competencies', done => {
+      mockCountCompetencies.mockResolvedValue(0);
       mockListCompetencies.mockRejectedValue(new Error());
       appAgent.get('/').expect(500, done);
     });

--- a/api/src/middleware/__tests__/competenciesRouter.ts
+++ b/api/src/middleware/__tests__/competenciesRouter.ts
@@ -1,0 +1,47 @@
+import { collectionEnvelope } from '../responseEnvelope';
+import {
+  countCompetencies,
+  listCompetencies,
+} from '../../services/competenciesService';
+import { createAppAgentForRouter } from '../routerTestUtils';
+import competenciesRouter from '../competenciesRouter';
+
+jest.mock('../../services/competenciesService.ts');
+const mockCountCompetencies = jest.mocked(countCompetencies);
+const mockListCompetencies = jest.mocked(listCompetencies);
+
+describe('competenciesRouter', () => {
+  const appAgent = createAppAgentForRouter(competenciesRouter);
+
+  describe('GET /', () => {
+    it('should respond with a paginated list of all the competencies', done => {
+      const competencies = [
+        {
+          id: 3,
+          label: 'label',
+          description: 'description',
+        },
+      ];
+      const competenciesCount = competencies.length;
+      mockCountCompetencies.mockResolvedValue(competenciesCount);
+      mockListCompetencies.mockResolvedValue(competencies);
+
+      appAgent
+        .get('/?page=2&perpage=1')
+        .expect(
+          200,
+          collectionEnvelope(competencies, competenciesCount),
+          err => {
+            expect(mockCountCompetencies).toHaveBeenCalled();
+            expect(mockListCompetencies).toHaveBeenCalledWith(1, 1);
+            done(err);
+          }
+        );
+    });
+
+    it('should respond with an internal server error if an error was thrown while listing competencies', done => {
+      mockListCompetencies.mockRejectedValue(new Error());
+      appAgent.get('/').expect(500, done);
+    });
+  });
+});

--- a/api/src/middleware/competenciesRouter.ts
+++ b/api/src/middleware/competenciesRouter.ts
@@ -1,0 +1,27 @@
+import { Router } from 'express';
+import { collectionEnvelope } from './responseEnvelope';
+import {
+  countCompetencies,
+  listCompetencies,
+} from '../services/competenciesService';
+import { parsePaginationParams } from './paginationParamsMiddleware';
+
+const competenciesRouter = Router();
+
+competenciesRouter.get('/', parsePaginationParams(), async (req, res, next) => {
+  const { limit, offset } = req.pagination;
+  let competencies;
+  let competenciesCount;
+  try {
+    [competencies, competenciesCount] = await Promise.all([
+      listCompetencies(limit, offset),
+      countCompetencies(),
+    ]);
+  } catch (err) {
+    next(err);
+    return;
+  }
+  res.json(collectionEnvelope(competencies, competenciesCount));
+});
+
+export default competenciesRouter;

--- a/api/src/middleware/competenciesRouter.ts
+++ b/api/src/middleware/competenciesRouter.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+
 import { collectionEnvelope } from './responseEnvelope';
 import {
   countCompetencies,

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -17,6 +17,7 @@ import meetingsRouter from './middleware/meetingsRouter';
 import questionnairesRouter from './middleware/questionnairesRouter';
 import reflectionsRouter from './middleware/reflectionsRouter';
 import settingsRouter from './middleware/settingsRouter';
+import competenciesRouter from './middleware/competenciesRouter';
 
 declare module 'express-session' {
   interface Session {
@@ -71,6 +72,7 @@ const start = async () => {
   app.use('/questionnaires', withCors, loggedIn, questionnairesRouter);
   app.use('/reflections', withCors, loggedIn, reflectionsRouter);
   app.use('/settings', withCors, settingsRouter);
+  app.use('/competencies', withCors, loggedIn, competenciesRouter);
   app.get('/', (_, res) => {
     res.json({});
   });

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -7,6 +7,7 @@ import expressSession from 'express-session';
 import helmet from 'helmet';
 
 import authRouter from './middleware/authRouter';
+import competenciesRouter from './middleware/competenciesRouter';
 import docsRouter from './middleware/docsRouter';
 import {
   handleErrors,
@@ -17,7 +18,6 @@ import meetingsRouter from './middleware/meetingsRouter';
 import questionnairesRouter from './middleware/questionnairesRouter';
 import reflectionsRouter from './middleware/reflectionsRouter';
 import settingsRouter from './middleware/settingsRouter';
-import competenciesRouter from './middleware/competenciesRouter';
 
 declare module 'express-session' {
   interface Session {
@@ -67,12 +67,13 @@ const start = async () => {
     origin: process.env.WEBAPP_ORIGIN,
   });
   app.use(withCors, authRouter);
+  app.use('/competencies', withCors, loggedIn, competenciesRouter);
   app.use('/docs', withCors, docsRouter);
   app.use('/meetings', withCors, loggedIn, meetingsRouter);
   app.use('/questionnaires', withCors, loggedIn, questionnairesRouter);
   app.use('/reflections', withCors, loggedIn, reflectionsRouter);
   app.use('/settings', withCors, settingsRouter);
-  app.use('/competencies', withCors, loggedIn, competenciesRouter);
+
   app.get('/', (_, res) => {
     res.json({});
   });

--- a/api/src/services/__tests__/competenciesService.ts
+++ b/api/src/services/__tests__/competenciesService.ts
@@ -1,7 +1,19 @@
-import { listCompetencies } from '../competenciesService';
+import { countCompetencies, listCompetencies } from '../competenciesService';
 import { mockQuery } from '../mockDb';
 
 describe('competenciesService', () => {
+  describe('countCompetencies', () => {
+    it('should count all the competencies in the database', async () => {
+      const competenciesCount = 2;
+      mockQuery(
+        'select count(*) as `total_count` from `competencies`',
+        [],
+        [{ total_count: competenciesCount }]
+      );
+      expect(await countCompetencies()).toEqual(competenciesCount);
+    });
+  });
+
   describe('listCompetencies', () => {
     it('should query the lists of the competencies in the database with their labels and descriptions', async () => {
       const competencies = [

--- a/api/src/services/competenciesService.ts
+++ b/api/src/services/competenciesService.ts
@@ -1,5 +1,11 @@
 import db from './db';
 
+export const countCompetencies = async () => {
+  const countAlias = 'total_count';
+  const [count] = await db('competencies').count({ [countAlias]: '*' });
+  return count[countAlias];
+};
+
 export const listCompetencies = async (limit: number, offset: number) => {
   const competencies = await db('competencies')
     .select('id', 'label', 'description')


### PR DESCRIPTION
## Proposed changes

- Add `countCompetencies` function into competencies service
- Add test for `countCompetencies` function in competencies service test
- Add `competenciesRouter`  get a request to show a paginated list of competencies
- Add `competenciesRouter`  get request test to show a paginated list of competencies and check/throw errors when counting or listing competencies.
- Add `competencies` routes in server file 

Resolves #272 

## Checklist

- [X] Are the issues being addressed linked to this PR?
- [X] Do all commit messages start with the issue number?
- [X] Are all code changes sufficiently tested?
- [X] Are there screenshots for UI changes? (N/A)
