### PR TITLE
Make competencies viewable from the app

### DIFF
--- a/webapp/src/components/App.tsx
+++ b/webapp/src/components/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import React, { useContext } from 'react';
 
+import CompetenciesPage from './CompetenciesPage';
 import DocPage from './DocPage';
 import Footer from './Footer';
 import MeetingPage from './MeetingPage';
@@ -9,7 +10,6 @@ import Navbar from './Navbar';
 import ReflectionsPage from './ReflectionsPage';
 import RequireAuth from './RequireAuth';
 import SessionContext from './SessionContext';
-import CompetenciesPage from './CompetenciesPage';
 
 const App = () => {
   const { isAuthenticated } = useContext(SessionContext);

--- a/webapp/src/components/App.tsx
+++ b/webapp/src/components/App.tsx
@@ -9,6 +9,7 @@ import Navbar from './Navbar';
 import ReflectionsPage from './ReflectionsPage';
 import RequireAuth from './RequireAuth';
 import SessionContext from './SessionContext';
+import CompetenciesPage from './CompetenciesPage';
 
 const App = () => {
   const { isAuthenticated } = useContext(SessionContext);
@@ -30,6 +31,14 @@ const App = () => {
             element={
               <RequireAuth>
                 <ReflectionsPage />
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="/competencies"
+            element={
+              <RequireAuth>
+                <CompetenciesPage />
               </RequireAuth>
             }
           />

--- a/webapp/src/components/CompetenciesPage.tsx
+++ b/webapp/src/components/CompetenciesPage.tsx
@@ -1,0 +1,30 @@
+import { Container } from '@mui/material';
+import React from 'react';
+
+import Competency from './Competency';
+import { Competency as APICompetency } from '../types/api';
+import useApiData from '../helpers/useApiData';
+
+const CompetenciesPage = () => {
+  const { data: competencies, error } = useApiData<APICompetency[]>({
+    deps: [],
+    path: `/competencies`,
+    sendCredentials: true,
+  });
+  if (error) {
+    return <div>There was an error loading the competencies.</div>;
+  }
+  if (!competencies) {
+    return null;
+  }
+  return (
+    <Container fixed>
+      {competencies.length === 0 && <p>There are no competencies.</p>}
+      {competencies.map(({ id, label, description }) => (
+        <Competency key={id} description={description} label={label} />
+      ))}
+    </Container>
+  );
+};
+
+export default CompetenciesPage;

--- a/webapp/src/components/CompetenciesPage.tsx
+++ b/webapp/src/components/CompetenciesPage.tsx
@@ -12,7 +12,7 @@ const CompetenciesPage = () => {
     sendCredentials: true,
   });
   if (error) {
-    return <div>There was an error loading the competencies.</div>;
+    return <p>There was an error loading the competencies.</p>;
   }
   if (!competencies) {
     return null;

--- a/webapp/src/components/Competency.tsx
+++ b/webapp/src/components/Competency.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface CompetencyProps {
+  label: string;
+  description: string;
+}
+
+const Competency = ({ label, description }: CompetencyProps) => (
+  <div>
+    <h2>{label}</h2>
+    <p>{description}</p>
+  </div>
+);
+
+export default Competency;

--- a/webapp/src/types/api.d.ts
+++ b/webapp/src/types/api.d.ts
@@ -12,6 +12,12 @@ export interface APIError {
   message: string;
 }
 
+export interface Competency {
+  id: EntityId;
+  label: string;
+  description: string;
+}
+
 export interface Doc {
   id: EntityId;
   slug: string;

--- a/webapp/src/types/api.d.ts
+++ b/webapp/src/types/api.d.ts
@@ -11,20 +11,16 @@ export interface CreationResponseEnvelope {
 export interface APIError {
   message: string;
 }
-
-export interface Competency {
-  id: EntityId;
-  label: string;
-  description: string;
-}
-
 export interface Doc {
   id: EntityId;
   slug: string;
   title: string;
   content: string;
 }
-
+export interface Competency extends Entity {
+  label: string;
+  description: string;
+}
 export interface Prompt extends Entity {
   label: string;
   options: Option[];


### PR DESCRIPTION
## Proposed changes

Adds a `/competencies` route to the webapp that displays a competencies page with data from the `/competencies` endpoint in the API.

Resolves #273 

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?

## Screenshots

![rhi zone-development_competencies](https://user-images.githubusercontent.com/3359121/152432754-ea3a4e79-0859-4868-a994-50b8c35d3ae0.png)

