### PR TITLE
Add api endpoint to create new competencies

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -28,3 +28,7 @@ process.env.DEBUG = '*';
 ```
 
 Nodemon should restart the server and the console will have debug messages.
+
+## Testing
+
+To run the tests, run `yarn test`.

--- a/api/src/middleware/competenciesRouter.ts
+++ b/api/src/middleware/competenciesRouter.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 
-import { collectionEnvelope } from './responseEnvelope';
+import { ValidationError } from './httpErrors';
+import { collectionEnvelope, itemEnvelope } from './responseEnvelope';
 import {
   countCompetencies,
   listCompetencies,
+  createCompetency,
 } from '../services/competenciesService';
 import { parsePaginationParams } from './paginationParamsMiddleware';
 
@@ -23,6 +25,27 @@ competenciesRouter.get('/', parsePaginationParams(), async (req, res, next) => {
     return;
   }
   res.json(collectionEnvelope(competencies, competenciesCount));
+});
+
+competenciesRouter.post('/', async (req, res, next) => {
+  const { principalId } = req.session;
+  const { label, description } = req.body;
+  if (typeof label !== 'string') {
+    next(new ValidationError('label must be a string'));
+    return;
+  }
+  if (typeof description !== 'string') {
+    next(new ValidationError('description must be a string'));
+    return;
+  }
+  let competency;
+  try {
+    competency = await createCompetency(principalId, label, description);
+  } catch (error) {
+    next(error);
+    return;
+  }
+  res.status(201).json(itemEnvelope(competency));
 });
 
 export default competenciesRouter;

--- a/api/src/services/__tests__/competenciesService.ts
+++ b/api/src/services/__tests__/competenciesService.ts
@@ -39,16 +39,24 @@ describe('competenciesService', () => {
   });
 
   describe('createCompetency', () => {
-    it('should create a given competency in the system', async () => {
+    it('should create a competency and model competency in a transaction', async () => {
       const principalId = 2;
       const label = 'label';
       const description = 'description';
       const competencyId = 3;
+      const model_competency_id = 4;
+      mockQuery('BEGIN;');
       mockQuery(
         'insert into `competencies` (`description`, `label`, `principal_id`) values (?, ?, ?)',
         [description, label, principalId],
         [competencyId]
       );
+      mockQuery(
+        'insert into `model_competencies` (`competency_id`, `principal_id`) values (?, ?)',
+        [competencyId, principalId],
+        [model_competency_id]
+      );
+      mockQuery('COMMIT;');
       expect(await createCompetency(principalId, label, description)).toEqual({
         id: competencyId,
       });

--- a/api/src/services/competenciesService.ts
+++ b/api/src/services/competenciesService.ts
@@ -20,10 +20,17 @@ export const createCompetency = async (
   label: string,
   description: string
 ) => {
-  const [id] = await db('competencies').insert({
-    principal_id: principalId,
-    label: label,
-    description: description,
+  let competencyId: number;
+  await db.transaction(async trx => {
+    [competencyId] = await trx('competencies').insert({
+      principal_id: principalId,
+      label: label,
+      description: description,
+    });
+    await trx('model_competencies').insert({
+      principal_id: principalId,
+      competency_id: competencyId,
+    });
   });
-  return { id };
+  return { id: competencyId };
 };


### PR DESCRIPTION
## Proposed changes
- Add and test a function to insert a given competency into the `competencies` table and to the authoring principal's `model_competencies` table.
- Add and test POST method to the `/competencies` API endpoint.

Resolves #274   

## Checklist

- [X] Are the issues being addressed linked to this PR?
- [X] Do all commit messages start with the issue number?
- [X] Are all code changes sufficiently tested?
- [X] Are there screenshots for UI changes?
