### PR TITLE
Build and push a production webapp image to replace Netlify webapp

### DIFF
--- a/.github/workflows/build_and_publish_images.yml
+++ b/.github/workflows/build_and_publish_images.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Log in to the Container registry
+      - name: Log in to the container registry
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Log in to the Container registry
+      - name: Log in to the container registry
         uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
@@ -68,6 +68,39 @@ jobs:
         with:
           context: ./nginx/
           build-args: BUILD_ENV=production
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+
+  build_and_push_webapp:
+    name: Build webapp image and push to registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Log in to the container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}_webapp
+          tags: |
+            type=sha
+            type=raw,value=latest
+      - name: Build and push webapp image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./webapp/
+          build-args: REACT_APP_API_ORIGIN=http://api.rhi.zone
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -20,6 +20,7 @@ services:
   nginx:
     depends_on:
       - api
+      - webapp
     image: ghcr.io/opentree-education/rhizone-lms_nginx:latest
     ports:
       - "80:80"
@@ -28,3 +29,5 @@ services:
       - /etc/letsencrypt/:/etc/letsencrypt/
   redis:
     image: redis:6.2-alpine
+  webapp:
+    image: ghcr.io/opentree-education/rhizone-lms_webapp:latest

--- a/nginx/production/nginx.conf
+++ b/nginx/production/nginx.conf
@@ -28,6 +28,10 @@ http {
     # for more information.
     include /etc/nginx/conf.d/*.conf;
 
+    upstream rhizone_lms_webapp {
+        server webapp:80;
+    }
+
     server {
         listen       80;
         listen       [::]:80;
@@ -47,9 +51,7 @@ http {
         } # managed by Certbot
 
         location / {
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header Host rhizone.netlify.app;
-            proxy_pass https://rhizone.netlify.app;
+            proxy_pass http://rhizone_lms_webapp;
         }
     }
 

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -7,4 +7,5 @@ RUN yarn install --ignore-platform --frozen-lockfile
 RUN yarn build
 
 FROM nginx:1.21-alpine
+COPY ./default.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/build/ /usr/share/nginx/html/

--- a/webapp/default.conf
+++ b/webapp/default.conf
@@ -1,0 +1,10 @@
+server {
+    listen       80 default_server;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html;
+        try_files $uri /index.html;
+    }
+}


### PR DESCRIPTION
## Proposed changes

Serve the webapp from its own container in production. Uses `try_files`, falling back to `index.html`, to address #292.

After this is shipped, `webapp/netlify.toml` can be removed and that site deleted, since the app will be built and served from our infrastructure instead.

Another step along the way to addressing #90.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
