### PR TITLE
Use https for api origin in webapp image

### DIFF
--- a/.github/workflows/build_and_publish_images.yml
+++ b/.github/workflows/build_and_publish_images.yml
@@ -100,7 +100,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./webapp/
-          build-args: REACT_APP_API_ORIGIN=http://api.rhi.zone
+          build-args: REACT_APP_API_ORIGIN=https://api.rhi.zone
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Proposed changes

Use https instead of http for api to prevent mixed content cors error.
