### PR TITLE
Remove netlify config since webapp is published in an image now

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,5 @@
 /docker-compose.production.yml @OpenTree-Education/production-engineers
 /webapp/.dockerignore @OpenTree-Education/production-engineers
 /webapp/Dockerfile @OpenTree-Education/production-engineers
-/webapp/netlify.toml @OpenTree-Education/production-engineers
 /webapp/package.json @OpenTree-Education/production-engineers
 /webapp/yarn.lock @OpenTree-Education/production-engineers

--- a/webapp/netlify.toml
+++ b/webapp/netlify.toml
@@ -1,4 +1,0 @@
-[build]
-  base = "webapp/"
-  publish = "build/"
-  command = "yarn build"


### PR DESCRIPTION
## Proposed changes

In simplifying the deployment, the webapp is published in an image that is run on the Docker stack now, so there's no need for any of the Netlify config. The Netlify site that previously hosted the webapp has been deleted.

Just another step in #90.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
