### PR TITLE
Run migrations in a container as a service in production

### DIFF
--- a/.github/workflows/build_and_publish_images.yml
+++ b/.github/workflows/build_and_publish_images.yml
@@ -40,6 +40,37 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  build_and_push_flyway:
+    name: Build flyway image and push to registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Log in to the container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}_flyway
+          tags: |
+            type=sha
+            type=raw,value=latest
+      - name: Build and push flyway image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./db/
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   build_and_push_nginx:
     name: Build nginx image and push to registry
     runs-on: ubuntu-latest

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -2,9 +2,6 @@ version: "3.7"
 
 services:
   api:
-    depends_on:
-      - flyway
-      - redis
     environment:
       - API_HOST=0.0.0.0
       - GITHUB_CLIENT_ID
@@ -26,9 +23,6 @@ services:
     secrets:
       - FLYWAY_CONFIG
   nginx:
-    depends_on:
-      - api
-      - webapp
     image: ghcr.io/opentree-education/rhizone-lms_nginx:latest
     ports:
       - "80:80"
@@ -38,6 +32,4 @@ services:
   redis:
     image: redis:6.2-alpine
   webapp:
-    depends_on:
-      - api
     image: ghcr.io/opentree-education/rhizone-lms_webapp:latest

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -3,6 +3,7 @@ version: "3.7"
 services:
   api:
     depends_on:
+      - flyway
       - redis
     environment:
       - API_HOST=0.0.0.0
@@ -17,6 +18,13 @@ services:
       - SESSION_SECRET
       - WEBAPP_ORIGIN=https://rhi.zone
     image: ghcr.io/opentree-education/rhizone-lms_api:latest
+  flyway:
+    command: -configFiles=/run/secrets/FLYWAY_CONFIG migrate
+    deploy:
+      replicas: 1
+    image: ghcr.io/opentree-education/rhizone-lms_flyway:latest
+    secrets:
+      - FLYWAY_CONFIG
   nginx:
     depends_on:
       - api
@@ -30,4 +38,6 @@ services:
   redis:
     image: redis:6.2-alpine
   webapp:
+    depends_on:
+      - api
     image: ghcr.io/opentree-education/rhizone-lms_webapp:latest


### PR DESCRIPTION
## Proposed changes

Build a flyway image on release, and run `flyway migrate` as a service when the production stack is deployed.

This is a big step toward #90.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
