### PR TITLE
Remove flyway service in prod stack because it keeps restarting

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -15,13 +15,6 @@ services:
       - SESSION_SECRET
       - WEBAPP_ORIGIN=https://rhi.zone
     image: ghcr.io/opentree-education/rhizone-lms_api:latest
-  flyway:
-    command: -configFiles=/run/secrets/FLYWAY_CONFIG migrate
-    deploy:
-      replicas: 1
-    image: ghcr.io/opentree-education/rhizone-lms_flyway:latest
-    secrets:
-      - FLYWAY_CONFIG
   nginx:
     image: ghcr.io/opentree-education/rhizone-lms_nginx:latest
     ports:


### PR DESCRIPTION
## Proposed changes

When deploying the production stack to the swarm, the flyway service continuously restarts even though it exits with `0`. Since we only want the migrations to run once per deploy, this is undesirable. Instead, flyway will have to be run as a one-off elsewhere in the pipeline. Until then, removing it from the stack config so we can deploy other stuff.

One step back in #90.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
