### PR TITLE
Add api endpoint for updating competencies

### DIFF
--- a/api/src/middleware/__tests__/competenciesRouter.ts
+++ b/api/src/middleware/__tests__/competenciesRouter.ts
@@ -1,8 +1,10 @@
 import { collectionEnvelope, itemEnvelope } from '../responseEnvelope';
 import {
+  authorizeCompetencyUpdate,
   countCompetencies,
   listCompetencies,
   createCompetency,
+  updateCompetency,
 } from '../../services/competenciesService';
 import { createAppAgentForRouter, mockPrincipalId } from '../routerTestUtils';
 import competenciesRouter from '../competenciesRouter';
@@ -11,6 +13,8 @@ jest.mock('../../services/competenciesService.ts');
 const mockCountCompetencies = jest.mocked(countCompetencies);
 const mockListCompetencies = jest.mocked(listCompetencies);
 const mockCreateCompetency = jest.mocked(createCompetency);
+const mockUpdateCompetency = jest.mocked(updateCompetency);
+const mockAuthorizeCompetencyUpdate = jest.mocked(authorizeCompetencyUpdate);
 
 describe('competenciesRouter', () => {
   const appAgent = createAppAgentForRouter(competenciesRouter);
@@ -62,6 +66,7 @@ describe('competenciesRouter', () => {
       const competencyId = 4;
       const competency = { id: competencyId };
       mockPrincipalId(principalId);
+
       mockCreateCompetency.mockResolvedValue(competency);
       appAgent
         .post('/')
@@ -97,6 +102,82 @@ describe('competenciesRouter', () => {
       mockCreateCompetency.mockRejectedValue(new Error());
       appAgent
         .post('/')
+        .send({
+          label: 'test',
+          description: 'test',
+        })
+        .expect(500, done);
+    });
+  });
+
+  describe('PUT /:id', () => {
+    it('should update a competency of user who authored it', done => {
+      const principalId = 2;
+      const competencyId = 3;
+      const label = 'label';
+      const description = 'description';
+      const competency = {
+        id: competencyId,
+      };
+      mockPrincipalId(principalId);
+      mockAuthorizeCompetencyUpdate.mockResolvedValue(true);
+      mockUpdateCompetency.mockResolvedValue();
+      appAgent
+        .put('/3')
+        .send({
+          label: label,
+          description: description,
+        })
+        .expect(200, itemEnvelope(competency), err => {
+          expect(mockAuthorizeCompetencyUpdate).toHaveBeenCalledWith(
+            principalId,
+            competencyId
+          );
+          expect(mockUpdateCompetency).toHaveBeenCalledWith(
+            competencyId,
+            label,
+            description
+          );
+          done(err);
+        });
+    });
+
+    it('should respond with a validation error if given id is less than 1', done => {
+      mockAuthorizeCompetencyUpdate.mockResolvedValue(true);
+      appAgent.put('/0').send({ label: '', description: '' }).expect(400, done);
+    });
+
+    it('should respond with an internal server error if an error was thrown while authorising a competency update', done => {
+      mockAuthorizeCompetencyUpdate.mockRejectedValue(new Error());
+      appAgent.put('/3').send({ label: '', description: '' }).expect(500, done);
+    });
+
+    it('should respond with a bad request error if user can not be authorised', done => {
+      mockAuthorizeCompetencyUpdate.mockResolvedValue(false);
+      appAgent.put('/3').send({ label: '', description: '' }).expect(404, done);
+    });
+
+    it('should respond with a validation error if label is not a string', done => {
+      mockAuthorizeCompetencyUpdate.mockResolvedValue(true);
+      appAgent
+        .put('/3')
+        .send({ label: null, description: '' })
+        .expect(422, done);
+    });
+
+    it('should respond with a validation error if description is not a string', done => {
+      mockAuthorizeCompetencyUpdate.mockResolvedValue(true);
+      appAgent
+        .put('/3')
+        .send({ label: '', description: null })
+        .expect(422, done);
+    });
+
+    it('should respond with an internal server error if an error is thrown when updating the competency', done => {
+      mockAuthorizeCompetencyUpdate.mockResolvedValue(true);
+      mockUpdateCompetency.mockRejectedValue(new Error());
+      appAgent
+        .put('/3')
         .send({
           label: 'test',
           description: 'test',

--- a/api/src/middleware/__tests__/competenciesRouter.ts
+++ b/api/src/middleware/__tests__/competenciesRouter.ts
@@ -10,11 +10,11 @@ import { createAppAgentForRouter, mockPrincipalId } from '../routerTestUtils';
 import competenciesRouter from '../competenciesRouter';
 
 jest.mock('../../services/competenciesService.ts');
-const mockCountCompetencies = jest.mocked(countCompetencies);
-const mockListCompetencies = jest.mocked(listCompetencies);
-const mockCreateCompetency = jest.mocked(createCompetency);
-const mockUpdateCompetency = jest.mocked(updateCompetency);
 const mockAuthorizeCompetencyUpdate = jest.mocked(authorizeCompetencyUpdate);
+const mockCountCompetencies = jest.mocked(countCompetencies);
+const mockCreateCompetency = jest.mocked(createCompetency);
+const mockListCompetencies = jest.mocked(listCompetencies);
+const mockUpdateCompetency = jest.mocked(updateCompetency);
 
 describe('competenciesRouter', () => {
   const appAgent = createAppAgentForRouter(competenciesRouter);
@@ -116,19 +116,15 @@ describe('competenciesRouter', () => {
       const competencyId = 3;
       const label = 'label';
       const description = 'description';
-      const competency = {
-        id: competencyId,
-      };
       mockPrincipalId(principalId);
       mockAuthorizeCompetencyUpdate.mockResolvedValue(true);
-      mockUpdateCompetency.mockResolvedValue();
       appAgent
         .put('/3')
         .send({
           label: label,
           description: description,
         })
-        .expect(200, itemEnvelope(competency), err => {
+        .expect(200, err => {
           expect(mockAuthorizeCompetencyUpdate).toHaveBeenCalledWith(
             principalId,
             competencyId
@@ -142,17 +138,12 @@ describe('competenciesRouter', () => {
         });
     });
 
-    it('should respond with a validation error if given id is less than 1', done => {
+    it('should respond with a bad request error if the given id is less than 1', done => {
       mockAuthorizeCompetencyUpdate.mockResolvedValue(true);
       appAgent.put('/0').send({ label: '', description: '' }).expect(400, done);
     });
 
-    it('should respond with an internal server error if an error was thrown while authorising a competency update', done => {
-      mockAuthorizeCompetencyUpdate.mockRejectedValue(new Error());
-      appAgent.put('/3').send({ label: '', description: '' }).expect(500, done);
-    });
-
-    it('should respond with a bad request error if user can not be authorised', done => {
+    it('should respond with not found if user can not be authorised', done => {
       mockAuthorizeCompetencyUpdate.mockResolvedValue(false);
       appAgent.put('/3').send({ label: '', description: '' }).expect(404, done);
     });
@@ -171,6 +162,11 @@ describe('competenciesRouter', () => {
         .put('/3')
         .send({ label: '', description: null })
         .expect(422, done);
+    });
+
+    it('should respond with an internal server error if an error was thrown while authorising a competency update', done => {
+      mockAuthorizeCompetencyUpdate.mockRejectedValue(new Error());
+      appAgent.put('/3').send({ label: '', description: '' }).expect(500, done);
     });
 
     it('should respond with an internal server error if an error is thrown when updating the competency', done => {

--- a/api/src/middleware/competenciesRouter.ts
+++ b/api/src/middleware/competenciesRouter.ts
@@ -90,7 +90,7 @@ competenciesRouter.put('/:id', async (req, res, next) => {
     next(error);
     return;
   }
-  res.status(200).json(itemEnvelope({ id: competencyId }));
+  res.json(itemEnvelope({ id: competencyId }));
 });
 
 export default competenciesRouter;

--- a/api/src/services/__tests__/competenciesService.ts
+++ b/api/src/services/__tests__/competenciesService.ts
@@ -80,7 +80,7 @@ describe('competenciesService', () => {
   });
 
   describe('authorizeCompetencyUpdate', () => {
-    it('should authorize the specific competency update ', async () => {
+    it('should return true if user is authorized to update specific competency', async () => {
       const principalId = 2;
       const competencyId = 3;
       mockQuery(
@@ -88,7 +88,22 @@ describe('competenciesService', () => {
         [competencyId, principalId],
         [{ id: competencyId }]
       );
-      await authorizeCompetencyUpdate(principalId, competencyId);
+      expect(
+        await authorizeCompetencyUpdate(principalId, competencyId)
+      ).toEqual(true);
+    });
+
+    it('should return false if user is not authorized to update the specific competency', async () => {
+      const principalId = 2;
+      const competencyId = 3;
+      mockQuery(
+        'select `id` from `competencies` where `id` = ? and `principal_id` = ?',
+        [competencyId, principalId],
+        []
+      );
+      expect(
+        await authorizeCompetencyUpdate(principalId, competencyId)
+      ).toEqual(false);
     });
   });
 });

--- a/api/src/services/__tests__/competenciesService.ts
+++ b/api/src/services/__tests__/competenciesService.ts
@@ -66,7 +66,7 @@ describe('competenciesService', () => {
   });
 
   describe('updateCompetency', () => {
-    it('should update the specified competency if the current user is the one who originally authored the competency', async () => {
+    it('should update the specified/selected competency', async () => {
       const id = 2;
       const label = 'label';
       const description = 'description';
@@ -77,13 +77,16 @@ describe('competenciesService', () => {
       );
       await updateCompetency(id, label, description);
     });
-    it('should authorizeCompetencyUpdate for a user who authored the competency', async () => {
+  });
+
+  describe('authorizeCompetencyUpdate', () => {
+    it('should authorize the specific competency update ', async () => {
       const principalId = 2;
       const competencyId = 3;
       mockQuery(
         'select `id` from `competencies` where `id` = ? and `principal_id` = ?',
         [competencyId, principalId],
-        [competencyId, principalId]
+        [competencyId]
       );
       await authorizeCompetencyUpdate(principalId, competencyId);
     });

--- a/api/src/services/__tests__/competenciesService.ts
+++ b/api/src/services/__tests__/competenciesService.ts
@@ -1,4 +1,5 @@
 import {
+  authorizeCompetencyUpdate,
   countCompetencies,
   listCompetencies,
   createCompetency,
@@ -66,21 +67,25 @@ describe('competenciesService', () => {
 
   describe('updateCompetency', () => {
     it('should update the specified competency if the current user is the one who originally authored the competency', async () => {
-      const competency = {
-        description: 'description',
-        id: 2,
-        label: 'label',
-        principal_id: 3,
-      };
       const id = 2;
-      const principalId = 3;
-
+      const label = 'label';
+      const description = 'description';
       mockQuery(
-        'select `description`, `id`, `label`, `principal_id` from `competencies` where `id` = ? and `principal_id` = ?',
-        [id, principalId],
-        competency
+        'update `competencies` set `label` = ?, `description` = ? where `id` = ?',
+        [label, description, id],
+        1
       );
-      expect(await updateCompetency(id, principalId)).toEqual(competency);
+      await updateCompetency(id, label, description);
+    });
+    it('should authorizeCompetencyUpdate for a user who authored the competency', async () => {
+      const principalId = 2;
+      const competencyId = 3;
+      mockQuery(
+        'select `id` from `competencies` where `id` = ? and `principal_id` = ?',
+        [competencyId, principalId],
+        [competencyId, principalId]
+      );
+      await authorizeCompetencyUpdate(principalId, competencyId);
     });
   });
 });

--- a/api/src/services/__tests__/competenciesService.ts
+++ b/api/src/services/__tests__/competenciesService.ts
@@ -86,7 +86,7 @@ describe('competenciesService', () => {
       mockQuery(
         'select `id` from `competencies` where `id` = ? and `principal_id` = ?',
         [competencyId, principalId],
-        [competencyId]
+        [{ id: competencyId }]
       );
       await authorizeCompetencyUpdate(principalId, competencyId);
     });

--- a/api/src/services/__tests__/competenciesService.ts
+++ b/api/src/services/__tests__/competenciesService.ts
@@ -2,6 +2,7 @@ import {
   countCompetencies,
   listCompetencies,
   createCompetency,
+  updateCompetency,
 } from '../competenciesService';
 import { mockQuery } from '../mockDb';
 
@@ -60,6 +61,26 @@ describe('competenciesService', () => {
       expect(await createCompetency(principalId, label, description)).toEqual({
         id: competencyId,
       });
+    });
+  });
+
+  describe('updateCompetency', () => {
+    it('should update the specified competency if the current user is the one who originally authored the competency', async () => {
+      const competency = {
+        description: 'description',
+        id: 2,
+        label: 'label',
+        principal_id: 3,
+      };
+      const id = 2;
+      const principalId = 3;
+
+      mockQuery(
+        'select `description`, `id`, `label`, `principal_id` from `competencies` where `id` = ? and `principal_id` = ?',
+        [id, principalId],
+        competency
+      );
+      expect(await updateCompetency(id, principalId)).toEqual(competency);
     });
   });
 });

--- a/api/src/services/competenciesService.ts
+++ b/api/src/services/competenciesService.ts
@@ -35,10 +35,18 @@ export const createCompetency = async (
   return { id: competencyId };
 };
 
-export const updateCompetency = async (id: number, principalId: number) => {
-  const competency = await db('competencies')
-    .select('description', 'id', 'label', 'principal_id')
-    .where({ id: id, principal_id: principalId });
+export const updateCompetency = (
+  id: number,
+  label: string,
+  description: string
+) => db('competencies').where({ id }).update({ label, description });
 
-  return competency;
+export const authorizeCompetencyUpdate = async (
+  principalId: number,
+  competencyId: number
+) => {
+  const [competency] = await db('competencies')
+    .select('id')
+    .where({ id: competencyId, principal_id: principalId });
+  return !!competency;
 };

--- a/api/src/services/competenciesService.ts
+++ b/api/src/services/competenciesService.ts
@@ -35,11 +35,13 @@ export const createCompetency = async (
   return { id: competencyId };
 };
 
-export const updateCompetency = (
+export const updateCompetency = async (
   id: number,
   label: string,
   description: string
-) => db('competencies').where({ id }).update({ label, description });
+) => {
+  await db('competencies').where({ id }).update({ label, description });
+};
 
 export const authorizeCompetencyUpdate = async (
   principalId: number,
@@ -48,5 +50,6 @@ export const authorizeCompetencyUpdate = async (
   const [competency] = await db('competencies')
     .select('id')
     .where({ id: competencyId, principal_id: principalId });
+
   return !!competency;
 };

--- a/api/src/services/competenciesService.ts
+++ b/api/src/services/competenciesService.ts
@@ -34,3 +34,11 @@ export const createCompetency = async (
   });
   return { id: competencyId };
 };
+
+export const updateCompetency = async (id: number, principalId: number) => {
+  const competency = await db('competencies')
+    .select('description', 'id', 'label', 'principal_id')
+    .where({ id: id, principal_id: principalId });
+
+  return competency;
+};


### PR DESCRIPTION
## Proposed changes

This is partial resolution for ticket #277.
updateCompetency function and test for querying a specific competency for a user who authored it.

## Checklist

- [X] Are the issues being addressed linked to this PR?
- [X] Do all commit messages start with the issue number?
- [X] Are all code changes sufficiently tested?
- [X] Are there screenshots for UI changes?
