### PR TITLE
Allow principal authors to edit competencies

### DIFF
--- a/api/src/services/__tests__/competenciesService.ts
+++ b/api/src/services/__tests__/competenciesService.ts
@@ -25,12 +25,13 @@ describe('competenciesService', () => {
           id: 2,
           label: 'label',
           description: 'description',
+          principal_id: 3,
         },
       ];
-      const limit = 3;
-      const offset = 4;
+      const limit = 4;
+      const offset = 5;
       mockQuery(
-        'select `id`, `label`, `description` from `competencies` order by `label` asc, `id` asc limit ? offset ?',
+        'select `id`, `principal_id`, `label`, `description` from `competencies` order by `label` asc, `id` asc limit ? offset ?',
         [limit, offset],
         competencies
       );

--- a/api/src/services/competenciesService.ts
+++ b/api/src/services/competenciesService.ts
@@ -8,7 +8,7 @@ export const countCompetencies = async () => {
 
 export const listCompetencies = async (limit: number, offset: number) => {
   const competencies = await db('competencies')
-    .select('id', 'label', 'description')
+    .select('id', 'principal_id', 'label', 'description')
     .orderBy('label', 'asc')
     .orderBy('id', 'asc')
     .limit(limit)
@@ -30,8 +30,8 @@ export const createCompetency = async (
       description: description,
     });
     await trx('model_competencies').insert({
-      principal_id: principalId,
       competency_id: competencyId,
+      principal_id: principalId,
     });
   });
   return { id: competencyId };

--- a/webapp/src/components/CompetenciesPage.tsx
+++ b/webapp/src/components/CompetenciesPage.tsx
@@ -7,11 +7,11 @@ import { EntityId, Competency as APICompetency } from '../types/api';
 import useApiData from '../helpers/useApiData';
 
 const CompetenciesPage = () => {
-  const [newlyCreatedCompetencyIds, setNewlyCreatedCompetencyIds] = useState<
+  const [changedCompetencyIds, setChangedCompetencyIds] = useState<
     EntityId[]
   >([]);
   const { data: competencies, error } = useApiData<APICompetency[]>({
-    deps: [newlyCreatedCompetencyIds],
+    deps: [changedCompetencyIds],
     path: `/competencies`,
     sendCredentials: true,
   });
@@ -28,15 +28,15 @@ const CompetenciesPage = () => {
         <Grid item xs={12} md={8}>
           <Box>
             <CreateCompetencyForm
-              onCompetencyCreated={id =>
-                setNewlyCreatedCompetencyIds([...newlyCreatedCompetencyIds, id])
-              }
+              onCompetenciesChanged={id =>
+                setChangedCompetencyIds([...changedCompetencyIds, id])}
             />
           </Box>
           <Box my={6}>
             {competencies.length === 0 && <p>There are no competencies.</p>}
             {competencies.map(({ id, label, description, principal_id }) => (
-              <Competency key={id} description={description} label={label} principal_id={principal_id} />
+              <Competency key={id} id={id} description={description} label={label} principal_id={principal_id} onCompetenciesChanged={id =>
+                setChangedCompetencyIds([...changedCompetencyIds, id])} />
             ))}
           </Box>
         </Grid>

--- a/webapp/src/components/CompetenciesPage.tsx
+++ b/webapp/src/components/CompetenciesPage.tsx
@@ -28,14 +28,14 @@ const CompetenciesPage = () => {
         <Grid item xs={12} md={8}>
           <Box>
             <CreateCompetencyForm
-              onCompetenciesChanged={id =>
+              onCompetencyChanged={id =>
                 setChangedCompetencyIds([...changedCompetencyIds, id])}
             />
           </Box>
           <Box my={6}>
             {competencies.length === 0 && <p>There are no competencies.</p>}
-            {competencies.map(({ id, label, description, principal_id }) => (
-              <Competency key={id} id={id} description={description} label={label} principal_id={principal_id} onCompetenciesChanged={id =>
+            {competencies.map(({ id, label, description, principal_id: principalId }) => (
+              <Competency key={id} id={id} description={description} label={label} principalId={principalId} onCompetencyChanged={id =>
                 setChangedCompetencyIds([...changedCompetencyIds, id])} />
             ))}
           </Box>

--- a/webapp/src/components/CompetenciesPage.tsx
+++ b/webapp/src/components/CompetenciesPage.tsx
@@ -2,7 +2,7 @@ import { Box, Container, Grid } from '@mui/material';
 import React, { useState } from 'react';
 
 import Competency from './Competency';
-import CreateCompetencyForm from './CreateCompetencyForm';
+import CreateOrUpdateCompetencyForm from './CreateOrUpdateCompetencyForm';
 import { EntityId, Competency as APICompetency } from '../types/api';
 import useApiData from '../helpers/useApiData';
 
@@ -27,7 +27,7 @@ const CompetenciesPage = () => {
       <Grid container justifyContent="center">
         <Grid item xs={12} md={8}>
           <Box>
-            <CreateCompetencyForm
+            <CreateOrUpdateCompetencyForm
               onCompetencyChanged={id =>
                 setChangedCompetencyIds([...changedCompetencyIds, id])
               }

--- a/webapp/src/components/CompetenciesPage.tsx
+++ b/webapp/src/components/CompetenciesPage.tsx
@@ -7,9 +7,9 @@ import { EntityId, Competency as APICompetency } from '../types/api';
 import useApiData from '../helpers/useApiData';
 
 const CompetenciesPage = () => {
-  const [changedCompetencyIds, setChangedCompetencyIds] = useState<
-    EntityId[]
-  >([]);
+  const [changedCompetencyIds, setChangedCompetencyIds] = useState<EntityId[]>(
+    []
+  );
   const { data: competencies, error } = useApiData<APICompetency[]>({
     deps: [changedCompetencyIds],
     path: `/competencies`,
@@ -29,15 +29,26 @@ const CompetenciesPage = () => {
           <Box>
             <CreateCompetencyForm
               onCompetencyChanged={id =>
-                setChangedCompetencyIds([...changedCompetencyIds, id])}
+                setChangedCompetencyIds([...changedCompetencyIds, id])
+              }
             />
           </Box>
           <Box my={6}>
             {competencies.length === 0 && <p>There are no competencies.</p>}
-            {competencies.map(({ id, label, description, principal_id: principalId }) => (
-              <Competency key={id} id={id} description={description} label={label} principalId={principalId} onCompetencyChanged={id =>
-                setChangedCompetencyIds([...changedCompetencyIds, id])} />
-            ))}
+            {competencies.map(
+              ({ id, label, description, principal_id: principalId }) => (
+                <Competency
+                  key={id}
+                  id={id}
+                  description={description}
+                  label={label}
+                  principalId={principalId}
+                  onCompetencyChanged={id =>
+                    setChangedCompetencyIds([...changedCompetencyIds, id])
+                  }
+                />
+              )
+            )}
           </Box>
         </Grid>
       </Grid>

--- a/webapp/src/components/CompetenciesPage.tsx
+++ b/webapp/src/components/CompetenciesPage.tsx
@@ -35,8 +35,8 @@ const CompetenciesPage = () => {
           </Box>
           <Box my={6}>
             {competencies.length === 0 && <p>There are no competencies.</p>}
-            {competencies.map(({ id, label, description }) => (
-              <Competency key={id} description={description} label={label} />
+            {competencies.map(({ id, label, description, principal_id }) => (
+              <Competency key={id} description={description} label={label} principal_id={principal_id} />
             ))}
           </Box>
         </Grid>

--- a/webapp/src/components/Competency.tsx
+++ b/webapp/src/components/Competency.tsx
@@ -1,29 +1,29 @@
 import { Button } from '@mui/material';
 import React, { useContext, useState } from 'react';
-import CreateCompetencyForm from './CreateCompetencyForm';
-import SessionContext from './SessionContext';
 
+import CreateCompetencyForm from './CreateCompetencyForm';
 import { EntityId } from '../types/api';
+import SessionContext from './SessionContext';
 
 interface CompetencyProps {
   description: string;
   id: EntityId;
   label: string;
-  onCompetenciesChanged?: (id: EntityId) => void;
-  principal_id: EntityId;
+  onCompetencyChanged?: (id: EntityId) => void;
+  principalId: EntityId;
 }
 
-const Competency = ({ description, id, label, onCompetenciesChanged, principal_id }: CompetencyProps) => {
-  const { principalId } = useContext(SessionContext);
+const Competency = ({ description, id, label, onCompetencyChanged, principalId }: CompetencyProps) => {
+  const { principalId: sessionPrincipalId } = useContext(SessionContext);
   const [toggleForm, setToggleForm] = useState(false);
 
   return (
     <div>
       <h2>{label}</h2>
       <p>{description}</p>
-      {principal_id === principalId && <Button onClick={() => setToggleForm(true)}>Edit Competency</Button>}
+      {principalId === sessionPrincipalId && <Button onClick={() => setToggleForm(true)}>Edit Competency</Button>}
       {toggleForm && <CreateCompetencyForm competencyId={id}
-        onCompetenciesChanged={onCompetenciesChanged} defaultLabel={label} defaultDescription={description} />
+        onCompetencyChanged={onCompetencyChanged} defaultLabel={label} defaultDescription={description} />
       }
     </div>
   );

--- a/webapp/src/components/Competency.tsx
+++ b/webapp/src/components/Competency.tsx
@@ -1,20 +1,30 @@
-import React, { useContext } from 'react';
+import { Button } from '@mui/material';
+import React, { useContext, useState } from 'react';
+import CreateCompetencyForm from './CreateCompetencyForm';
 import SessionContext from './SessionContext';
 
+import { EntityId } from '../types/api';
 
 interface CompetencyProps {
-  label: string;
   description: string;
-  principal_id: number;
+  id: EntityId;
+  label: string;
+  onCompetenciesChanged?: (id: EntityId) => void;
+  principal_id: EntityId;
 }
 
-const Competency = ({ label, description, principal_id }: CompetencyProps) => {
+const Competency = ({ description, id, label, onCompetenciesChanged, principal_id }: CompetencyProps) => {
   const { principalId } = useContext(SessionContext);
+  const [toggleForm, setToggleForm] = useState(false);
 
   return (
     <div>
       <h2>{label}</h2>
       <p>{description}</p>
+      {principal_id === principalId && <Button onClick={() => setToggleForm(true)}>Edit Competency</Button>}
+      {toggleForm && <CreateCompetencyForm competencyId={id}
+        onCompetenciesChanged={onCompetenciesChanged} defaultLabel={label} defaultDescription={description} />
+      }
     </div>
   );
 };

--- a/webapp/src/components/Competency.tsx
+++ b/webapp/src/components/Competency.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@mui/material';
 import React, { useContext, useState } from 'react';
 
-import CreateCompetencyForm from './CreateCompetencyForm';
+import CreateOrUpdateCompetencyForm from './CreateOrUpdateCompetencyForm';
 import { EntityId } from '../types/api';
 import SessionContext from './SessionContext';
 
@@ -33,7 +33,7 @@ const Competency = ({
         </Button>
       )}
       {toggleForm && (
-        <CreateCompetencyForm
+        <CreateOrUpdateCompetencyForm
           competencyId={id}
           onCompetencyChanged={onCompetencyChanged}
           defaultLabel={label}

--- a/webapp/src/components/Competency.tsx
+++ b/webapp/src/components/Competency.tsx
@@ -21,21 +21,26 @@ const Competency = ({
   principalId,
 }: CompetencyProps) => {
   const { principalId: sessionPrincipalId } = useContext(SessionContext);
-  const [toggleForm, setToggleForm] = useState(false);
+  const [isFormShown, setIsFormShown] = useState(false);
 
   return (
     <div>
       <h2>{label}</h2>
       <p>{description}</p>
       {principalId === sessionPrincipalId && (
-        <Button onClick={() => setToggleForm(!toggleForm)}>
+        <Button onClick={() => setIsFormShown(!isFormShown)}>
           Edit Competency
         </Button>
       )}
-      {toggleForm && (
+      {isFormShown && (
         <CreateOrUpdateCompetencyForm
           competencyId={id}
-          onCompetencyChanged={onCompetencyChanged}
+          onCompetencyChanged={id => {
+            if (onCompetencyChanged) {
+              onCompetencyChanged(id);
+            }
+            setIsFormShown(false);
+          }}
           defaultLabel={label}
           defaultDescription={description}
         />

--- a/webapp/src/components/Competency.tsx
+++ b/webapp/src/components/Competency.tsx
@@ -21,7 +21,7 @@ const Competency = ({ description, id, label, onCompetencyChanged, principalId }
     <div>
       <h2>{label}</h2>
       <p>{description}</p>
-      {principalId === sessionPrincipalId && <Button onClick={() => setToggleForm(true)}>Edit Competency</Button>}
+      {principalId === sessionPrincipalId && <Button onClick={() => setToggleForm(!toggleForm)}>Edit Competency</Button>}
       {toggleForm && <CreateCompetencyForm competencyId={id}
         onCompetencyChanged={onCompetencyChanged} defaultLabel={label} defaultDescription={description} />
       }

--- a/webapp/src/components/Competency.tsx
+++ b/webapp/src/components/Competency.tsx
@@ -1,15 +1,22 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import SessionContext from './SessionContext';
+
 
 interface CompetencyProps {
   label: string;
   description: string;
+  principal_id: number;
 }
 
-const Competency = ({ label, description }: CompetencyProps) => (
-  <div>
-    <h2>{label}</h2>
-    <p>{description}</p>
-  </div>
-);
+const Competency = ({ label, description, principal_id }: CompetencyProps) => {
+  const { principalId } = useContext(SessionContext);
+
+  return (
+    <div>
+      <h2>{label}</h2>
+      <p>{description}</p>
+    </div>
+  );
+};
 
 export default Competency;

--- a/webapp/src/components/Competency.tsx
+++ b/webapp/src/components/Competency.tsx
@@ -13,7 +13,13 @@ interface CompetencyProps {
   principalId: EntityId;
 }
 
-const Competency = ({ description, id, label, onCompetencyChanged, principalId }: CompetencyProps) => {
+const Competency = ({
+  description,
+  id,
+  label,
+  onCompetencyChanged,
+  principalId,
+}: CompetencyProps) => {
   const { principalId: sessionPrincipalId } = useContext(SessionContext);
   const [toggleForm, setToggleForm] = useState(false);
 
@@ -21,10 +27,19 @@ const Competency = ({ description, id, label, onCompetencyChanged, principalId }
     <div>
       <h2>{label}</h2>
       <p>{description}</p>
-      {principalId === sessionPrincipalId && <Button onClick={() => setToggleForm(!toggleForm)}>Edit Competency</Button>}
-      {toggleForm && <CreateCompetencyForm competencyId={id}
-        onCompetencyChanged={onCompetencyChanged} defaultLabel={label} defaultDescription={description} />
-      }
+      {principalId === sessionPrincipalId && (
+        <Button onClick={() => setToggleForm(!toggleForm)}>
+          Edit Competency
+        </Button>
+      )}
+      {toggleForm && (
+        <CreateCompetencyForm
+          competencyId={id}
+          onCompetencyChanged={onCompetencyChanged}
+          defaultLabel={label}
+          defaultDescription={description}
+        />
+      )}
     </div>
   );
 };

--- a/webapp/src/components/CreateCompetencyForm.tsx
+++ b/webapp/src/components/CreateCompetencyForm.tsx
@@ -5,24 +5,32 @@ import React, { FormEventHandler, useState } from 'react';
 import { EntityId } from '../types/api';
 
 interface CreateCompetencyFormProps {
-  onCompetencyCreated?: (id: EntityId) => void;
+  competencyId?: EntityId;
+  defaultDescription?: string;
+  defaultLabel?: string;
+  id?: EntityId;
+  onCompetenciesChanged?: (id: EntityId) => void;
 }
 
 const CreateCompetencyForm = ({
-  onCompetencyCreated,
+  defaultDescription = '',
+  defaultLabel = '',
+  competencyId,
+  onCompetenciesChanged,
 }: CreateCompetencyFormProps) => {
   const [isSavingCompetency, setIsSavingCompetency] = useState(false);
   const [saveCompetencyError, setSaveCompetencyError] = useState(null);
   const [isSuccessMessageVisible, setIsSuccessMessageVisible] = useState(false);
-  const [competencyNameEntryText, setCompetencyNameEntryText] = useState('');
-  const [descriptionEntryText, setDescriptionEntryText] = useState('');
+  const [competencyNameEntryText, setCompetencyNameEntryText] = useState(defaultLabel);
+  const [descriptionEntryText, setDescriptionEntryText] = useState(defaultDescription);
   const [wasCompetencyEntryTextTouched, setWasCompetencyEntryTextTouched] =
     useState(false);
   const onSubmit: FormEventHandler = event => {
     event.preventDefault();
     setIsSavingCompetency(true);
-    fetch(`${process.env.REACT_APP_API_ORIGIN}/competencies`, {
-      method: 'POST',
+
+    fetch(`${process.env.REACT_APP_API_ORIGIN}/competencies/${competencyId}`, {
+      method: competencyId ? 'PUT' : 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -40,8 +48,8 @@ const CreateCompetencyForm = ({
           setIsSuccessMessageVisible(true);
           setCompetencyNameEntryText('');
           setDescriptionEntryText('');
-          if (onCompetencyCreated) {
-            onCompetencyCreated(data.id);
+          if (onCompetenciesChanged) {
+            onCompetenciesChanged(data.id);
           }
         }
       })
@@ -54,7 +62,7 @@ const CreateCompetencyForm = ({
     <form onSubmit={onSubmit}>
       <Card>
         <CardContent sx={{ pb: 0 }}>
-          <h2>New Competency</h2>
+          {competencyId ? <h3>Edit Competency</h3> : <h2>New Competency</h2>}
         </CardContent>
         <CardContent sx={{ pt: 0 }}>
           <TextField

--- a/webapp/src/components/CreateCompetencyForm.tsx
+++ b/webapp/src/components/CreateCompetencyForm.tsx
@@ -21,23 +21,30 @@ const CreateCompetencyForm = ({
   const [isSavingCompetency, setIsSavingCompetency] = useState(false);
   const [saveCompetencyError, setSaveCompetencyError] = useState(null);
   const [isSuccessMessageVisible, setIsSuccessMessageVisible] = useState(false);
-  const [competencyNameEntryText, setCompetencyNameEntryText] = useState(defaultLabel);
-  const [descriptionEntryText, setDescriptionEntryText] = useState(defaultDescription);
+  const [competencyNameEntryText, setCompetencyNameEntryText] =
+    useState(defaultLabel);
+  const [descriptionEntryText, setDescriptionEntryText] =
+    useState(defaultDescription);
   const [wasCompetencyEntryTextTouched, setWasCompetencyEntryTextTouched] =
     useState(false);
   const onSubmit: FormEventHandler = event => {
     event.preventDefault();
     setIsSavingCompetency(true);
 
-    fetch(competencyId ? `${process.env.REACT_APP_API_ORIGIN}/competencies/${competencyId}` : `${process.env.REACT_APP_API_ORIGIN}/competencies/`, {
-      method: competencyId ? 'PUT' : 'POST',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        label: competencyNameEntryText,
-        description: descriptionEntryText,
-      }),
-    })
+    fetch(
+      competencyId
+        ? `${process.env.REACT_APP_API_ORIGIN}/competencies/${competencyId}`
+        : `${process.env.REACT_APP_API_ORIGIN}/competencies/`,
+      {
+        method: competencyId ? 'PUT' : 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          label: competencyNameEntryText,
+          description: descriptionEntryText,
+        }),
+      }
+    )
       .then(res => res.json())
       .then(({ data, error }) => {
         setIsSavingCompetency(false);
@@ -62,7 +69,7 @@ const CreateCompetencyForm = ({
     <form onSubmit={onSubmit}>
       <Card>
         <CardContent sx={{ pb: 0 }}>
-          {competencyId ? <h3>Edit Competency</h3> : <h2>New Competency</h2>}
+          {competencyId ? <h3>Edit Competency</h3> : <h3>New Competency</h3>}
         </CardContent>
         <CardContent sx={{ pt: 0 }}>
           <TextField

--- a/webapp/src/components/CreateCompetencyForm.tsx
+++ b/webapp/src/components/CreateCompetencyForm.tsx
@@ -9,14 +9,14 @@ interface CreateCompetencyFormProps {
   defaultDescription?: string;
   defaultLabel?: string;
   id?: EntityId;
-  onCompetenciesChanged?: (id: EntityId) => void;
+  onCompetencyChanged?: (id: EntityId) => void;
 }
 
 const CreateCompetencyForm = ({
   defaultDescription = '',
   defaultLabel = '',
   competencyId,
-  onCompetenciesChanged,
+  onCompetencyChanged,
 }: CreateCompetencyFormProps) => {
   const [isSavingCompetency, setIsSavingCompetency] = useState(false);
   const [saveCompetencyError, setSaveCompetencyError] = useState(null);
@@ -29,7 +29,7 @@ const CreateCompetencyForm = ({
     event.preventDefault();
     setIsSavingCompetency(true);
 
-    fetch(`${process.env.REACT_APP_API_ORIGIN}/competencies/${competencyId}`, {
+    fetch(competencyId ? `${process.env.REACT_APP_API_ORIGIN}/competencies/${competencyId}` : `${process.env.REACT_APP_API_ORIGIN}/competencies/`, {
       method: competencyId ? 'PUT' : 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
@@ -48,8 +48,8 @@ const CreateCompetencyForm = ({
           setIsSuccessMessageVisible(true);
           setCompetencyNameEntryText('');
           setDescriptionEntryText('');
-          if (onCompetenciesChanged) {
-            onCompetenciesChanged(data.id);
+          if (onCompetencyChanged) {
+            onCompetencyChanged(data.id);
           }
         }
       })

--- a/webapp/src/components/CreateOrUpdateCompetencyForm.tsx
+++ b/webapp/src/components/CreateOrUpdateCompetencyForm.tsx
@@ -21,7 +21,7 @@ const CreateOrUpdateCompetencyForm = ({
   const [isSavingCompetency, setIsSavingCompetency] = useState(false);
   const [saveCompetencyError, setSaveCompetencyError] = useState(null);
   const [isSuccessMessageVisible, setIsSuccessMessageVisible] = useState(false);
-  const [competencyNameEntryText, setCompetencyNameEntryText] =
+  const [competencyLabelEntryText, setCompetencyLabelEntryText] =
     useState(defaultLabel);
   const [descriptionEntryText, setDescriptionEntryText] =
     useState(defaultDescription);
@@ -40,7 +40,7 @@ const CreateOrUpdateCompetencyForm = ({
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          label: competencyNameEntryText,
+          label: competencyLabelEntryText,
           description: descriptionEntryText,
         }),
       }
@@ -53,7 +53,7 @@ const CreateOrUpdateCompetencyForm = ({
         }
         if (data) {
           setIsSuccessMessageVisible(true);
-          setCompetencyNameEntryText('');
+          setCompetencyLabelEntryText('');
           setDescriptionEntryText('');
           if (onCompetencyChanged) {
             onCompetencyChanged(data.id);
@@ -76,8 +76,8 @@ const CreateOrUpdateCompetencyForm = ({
             required
             sx={{ mb: 2, width: '50%' }}
             label="Title"
-            onChange={event => setCompetencyNameEntryText(event.target.value)}
-            value={competencyNameEntryText}
+            onChange={event => setCompetencyLabelEntryText(event.target.value)}
+            value={competencyLabelEntryText}
           />
           <TextField
             required

--- a/webapp/src/components/CreateOrUpdateCompetencyForm.tsx
+++ b/webapp/src/components/CreateOrUpdateCompetencyForm.tsx
@@ -53,8 +53,10 @@ const CreateOrUpdateCompetencyForm = ({
         }
         if (data) {
           setIsSuccessMessageVisible(true);
-          setCompetencyLabelEntryText('');
-          setDescriptionEntryText('');
+          if (!competencyId) {
+            setCompetencyLabelEntryText('');
+            setDescriptionEntryText('');
+          }
           if (onCompetencyChanged) {
             onCompetencyChanged(data.id);
           }

--- a/webapp/src/components/CreateOrUpdateCompetencyForm.tsx
+++ b/webapp/src/components/CreateOrUpdateCompetencyForm.tsx
@@ -4,7 +4,7 @@ import React, { FormEventHandler, useState } from 'react';
 
 import { EntityId } from '../types/api';
 
-interface CreateCompetencyFormProps {
+interface CreateOrUpdateCompetencyFormProps {
   competencyId?: EntityId;
   defaultDescription?: string;
   defaultLabel?: string;
@@ -12,12 +12,12 @@ interface CreateCompetencyFormProps {
   onCompetencyChanged?: (id: EntityId) => void;
 }
 
-const CreateCompetencyForm = ({
+const CreateOrUpdateCompetencyForm = ({
   defaultDescription = '',
   defaultLabel = '',
   competencyId,
   onCompetencyChanged,
-}: CreateCompetencyFormProps) => {
+}: CreateOrUpdateCompetencyFormProps) => {
   const [isSavingCompetency, setIsSavingCompetency] = useState(false);
   const [saveCompetencyError, setSaveCompetencyError] = useState(null);
   const [isSuccessMessageVisible, setIsSuccessMessageVisible] = useState(false);
@@ -129,4 +129,4 @@ const CreateCompetencyForm = ({
   );
 };
 
-export default CreateCompetencyForm;
+export default CreateOrUpdateCompetencyForm;

--- a/webapp/src/components/CreateOrUpdateCompetencyForm.tsx
+++ b/webapp/src/components/CreateOrUpdateCompetencyForm.tsx
@@ -32,9 +32,7 @@ const CreateOrUpdateCompetencyForm = ({
     setIsSavingCompetency(true);
 
     fetch(
-      competencyId
-        ? `${process.env.REACT_APP_API_ORIGIN}/competencies/${competencyId}`
-        : `${process.env.REACT_APP_API_ORIGIN}/competencies/`,
+      `${process.env.REACT_APP_API_ORIGIN}/competencies/${competencyId || ''}`,
       {
         method: competencyId ? 'PUT' : 'POST',
         credentials: 'include',

--- a/webapp/src/types/api.d.ts
+++ b/webapp/src/types/api.d.ts
@@ -20,6 +20,7 @@ export interface Doc {
 export interface Competency extends Entity {
   label: string;
   description: string;
+  principal_id: number;
 }
 export interface Prompt extends Entity {
   label: string;


### PR DESCRIPTION
## Proposed changes

Refactors the Create Competency Form in order to allow users to edit competencies they've authored.
Adds UI changes in order to populate edit form.

## Checklist

- [X] Are the issues being addressed linked to this PR?
- [X] Do all commit messages start with the issue number?
- [X] Are all code changes sufficiently tested?
- [X] Are there screenshots for UI changes?

<img width="603" alt="Screen Shot 2022-02-10 at 2 32 43 PM" src="https://user-images.githubusercontent.com/82873669/153500099-69cf0a57-c5c1-4f17-b6fb-39c177753707.png">

