### PR TITLE
Optionally get config from secrets files

### DIFF
--- a/api/src/middleware/authRouter.ts
+++ b/api/src/middleware/authRouter.ts
@@ -1,15 +1,16 @@
 import { Router } from 'express';
 
+import { BadRequestError } from './httpErrors';
 import {
   createGithubUser,
   findGithubUserByGithubId,
 } from '../services/githubUsersService';
+import { findConfig } from '../services/configService';
 import {
   getGithubAccessToken,
   getGithubUser,
 } from '../services/githubApiService';
 import { itemEnvelope } from './responseEnvelope';
-import { BadRequestError } from './httpErrors';
 
 const authRouter = Router();
 
@@ -20,14 +21,14 @@ authRouter.get('/auth/session', (req, res) => {
 
 authRouter.get('/auth/logout', (req, res) => {
   req.session.destroy(() => {
-    res.redirect(process.env.WEBAPP_ORIGIN);
+    res.redirect(findConfig('WEBAPP_ORIGIN', ''));
   });
 });
 
 authRouter.get('/auth/github/login', (req, res) => {
   const params = new URLSearchParams();
-  params.set('client_id', process.env.GITHUB_CLIENT_ID);
-  params.set('redirect_uri', process.env.GITHUB_REDIRECT_URI);
+  params.set('client_id', findConfig('GITHUB_CLIENT_ID', ''));
+  params.set('redirect_uri', findConfig('GITHUB_REDIRECT_URI', ''));
   res.redirect(`https://github.com/login/oauth/authorize?${params.toString()}`);
 });
 
@@ -68,7 +69,7 @@ authRouter.get(`/auth/github/callback`, async (req, res, next) => {
     }
   }
   req.session.principalId = githubUser.principal_id;
-  res.redirect(process.env.WEBAPP_ORIGIN);
+  res.redirect(findConfig('WEBAPP_ORIGIN', ''));
 });
 
 export default authRouter;

--- a/api/src/services/__tests__/configService.ts
+++ b/api/src/services/__tests__/configService.ts
@@ -1,0 +1,57 @@
+import { existsSync, readFileSync } from 'fs';
+
+import { clearConfig, findConfig } from '../configService';
+
+jest.mock('fs');
+const mockExistsSync = jest.mocked(existsSync);
+const mockReadFileSync = jest.mocked(readFileSync);
+
+describe('configService', () => {
+  describe('findConfig', () => {
+    it('should read a secrets file if one exists with the key name', () => {
+      const key = 'TEST_KEY';
+      const secretValue = 'secret value';
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(secretValue);
+      expect(findConfig(key, 'default value')).toEqual(secretValue);
+      expect(mockExistsSync).toHaveBeenCalledWith(`/run/secrets/${key}`);
+      expect(mockReadFileSync).toHaveBeenCalledWith(
+        `/run/secrets/${key}`,
+        'utf-8'
+      );
+      clearConfig(key);
+    });
+
+    it("should read the config from the environment if a secrets file doesn't exist with the file name", () => {
+      const key = 'TEST_KEY';
+      process.env[key] = 'environment value';
+      mockExistsSync.mockReturnValue(false);
+      expect(findConfig(key, 'default value')).toEqual(process.env[key]);
+      expect(mockExistsSync).toHaveBeenCalledWith(`/run/secrets/${key}`);
+      expect(mockReadFileSync).not.toHaveBeenCalled();
+      delete process.env[key];
+      clearConfig(key);
+    });
+
+    it('should use the default value if the config is nether a secret nor in the environment', () => {
+      const key = 'TEST_KEY';
+      const defaultValue = 'default value';
+      mockExistsSync.mockReturnValue(false);
+      expect(findConfig(key, defaultValue)).toEqual(defaultValue);
+      expect(mockExistsSync).toHaveBeenCalledWith(`/run/secrets/${key}`);
+      expect(mockReadFileSync).not.toHaveBeenCalled();
+      clearConfig(key);
+    });
+
+    it('should memoize config once it has been found', () => {
+      const key = 'TEST_KEY';
+      const defaultValue = 'default value';
+      mockExistsSync.mockReturnValue(false);
+      findConfig(key, defaultValue);
+      findConfig(key, defaultValue);
+      expect(mockExistsSync.mock.calls.length).toEqual(1);
+      expect(mockReadFileSync).not.toHaveBeenCalled();
+      clearConfig(key);
+    });
+  });
+});

--- a/api/src/services/__tests__/githubApiService.ts
+++ b/api/src/services/__tests__/githubApiService.ts
@@ -16,7 +16,7 @@ describe('githubApiService', () => {
       } as Response);
       expect(await getGithubAccessToken(code)).toEqual(accessToken);
       expect(mockRequestPost).toHaveBeenCalledWith(
-        `https://github.com/login/oauth/access_token?client_id=undefined&client_secret=undefined&code=${code}`
+        `https://github.com/login/oauth/access_token?client_id=&client_secret=&code=${code}`
       );
     });
 

--- a/api/src/services/configService.ts
+++ b/api/src/services/configService.ts
@@ -1,0 +1,19 @@
+import { existsSync, readFileSync } from 'fs';
+
+const memo = new Map();
+
+export const findConfig = (key: string, defaultValue: string) => {
+  if (memo.has(key)) {
+    return memo.get(key);
+  }
+  const fileLocation = `/run/secrets/${key}`;
+  const config = existsSync(fileLocation)
+    ? readFileSync(fileLocation, 'utf-8')
+    : process.env[key] || defaultValue;
+  memo.set(key, config);
+  return config;
+};
+
+export const clearConfig = (key: string) => {
+  memo.delete(key);
+};

--- a/api/src/services/db.ts
+++ b/api/src/services/db.ts
@@ -1,12 +1,14 @@
 import knex from 'knex';
 
+import { findConfig } from './configService';
+
 const db = knex({
   client: 'mysql',
   connection: {
-    database: process.env.MYSQL_DATABASE,
-    host: process.env.MYSQL_HOST || 'localhost',
-    password: process.env.MYSQL_PASSWORD,
-    user: process.env.MYSQL_USER,
+    database: findConfig('MYSQL_DATABASE', ''),
+    host: findConfig('MYSQL_HOST', 'localhost'),
+    password: findConfig('MYSQL_PASSWORD', ''),
+    user: findConfig('MYSQL_USER', ''),
   },
 });
 

--- a/api/src/services/githubApiService.ts
+++ b/api/src/services/githubApiService.ts
@@ -1,9 +1,10 @@
+import { findConfig } from './configService';
 import request from './request';
 
 export const getGithubAccessToken = async (code: string) => {
   const params = new URLSearchParams();
-  params.set('client_id', process.env.GITHUB_CLIENT_ID);
-  params.set('client_secret', process.env.GITHUB_CLIENT_SECRET);
+  params.set('client_id', findConfig('GITHUB_CLIENT_ID', ''));
+  params.set('client_secret', findConfig('GITHUB_CLIENT_SECRET', ''));
   params.set('code', code);
   const response = await request.post(
     `https://github.com/login/oauth/access_token?${params.toString()}`


### PR DESCRIPTION
## Proposed changes

Replaces uses of environment variables in the api with a service that first checks to see whether a Docker secret exists with the given key, then falls back to environment variables (for dev and test).

Resolves #303.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
