### PR TITLE
Swap prod secrets from environment variables to Docker secrets

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,20 +1,37 @@
 version: "3.7"
 
+secrets:
+  GITHUB_CLIENT_ID:
+    external: true
+  GITHUB_CLIENT_SECRET:
+    external: true
+  MYSQL_DATABASE:
+    external: true
+  MYSQL_HOST:
+    external: true
+  MYSQL_PASSWORD:
+    external: true
+  MYSQL_USER:
+    external: true
+  SESSION_SECRET:
+    external: true
+
 services:
   api:
     environment:
       - API_HOST=0.0.0.0
+      - GITHUB_REDIRECT_URI=https://api.rhi.zone/auth/github/callback
+      - REDIS_HOST=redis
+      - WEBAPP_ORIGIN=https://rhi.zone
+    image: ghcr.io/opentree-education/rhizone-lms_api:latest
+    secrets:
       - GITHUB_CLIENT_ID
       - GITHUB_CLIENT_SECRET
-      - GITHUB_REDIRECT_URI=https://api.rhi.zone/auth/github/callback
       - MYSQL_DATABASE
       - MYSQL_HOST
       - MYSQL_PASSWORD
       - MYSQL_USER
-      - REDIS_HOST=redis
       - SESSION_SECRET
-      - WEBAPP_ORIGIN=https://rhi.zone
-    image: ghcr.io/opentree-education/rhizone-lms_api:latest
   nginx:
     image: ghcr.io/opentree-education/rhizone-lms_nginx:latest
     ports:


### PR DESCRIPTION
## Proposed changes

Takes the environment variables that the production api service was using that contain secret values and configures them to be read from Docker secrets instead. 

Resolves #308.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
