### PR TITLE
Update express interactions with socket.IO

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1,4 +1,5 @@
 // istanbul ignore file
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import connectRedis from 'connect-redis';
 import cors from 'cors';
 import { createClient as createRedisClient } from 'redis';

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -30,6 +30,7 @@ declare module 'express-session' {
 
 declare module 'express-serve-static-core' {
   interface Request {
+    io: Server;
     pagination: {
       limit: number;
       offset: number;
@@ -47,35 +48,42 @@ const start = async () => {
   const io = new Server(server, {
     cors: {
       origin: [findConfig('WEBAPP_ORIGIN', '')],
+      credentials: true,
     },
   });
-
-  io.on('connection', socket => {
-    console.log(`Connection for ${socket.id}`);
-  });
-
-  app.set('trust proxy', 1);
-
-  app.use(helmet());
-  app.use(express.json());
-
   const RedisStore = connectRedis(expressSession);
   const redisClient = createRedisClient({
     host: findConfig('REDIS_HOST', 'localhost'),
   });
   redisClient.on('connect', () => console.log(`redis client connected`));
   redisClient.on('error', error => console.log(`redis client error: ${error}`));
-  app.use(
-    expressSession({
-      cookie: { sameSite: true, secure },
-      name: 'session_id',
-      resave: true,
-      saveUninitialized: true,
-      secret: findConfig('SESSION_SECRET', ''),
-      store: new RedisStore({ client: redisClient }),
-    })
-  );
 
+  const sessionMiddleware = expressSession({
+    cookie: { sameSite: true, secure },
+    name: 'session_id',
+    resave: true,
+    saveUninitialized: true,
+    secret: findConfig('SESSION_SECRET', ''),
+    store: new RedisStore({ client: redisClient }),
+  });
+
+  io.use((socket, next) => {
+    // This code was taken from the documentation for using Socket.IO with express-session:
+    // https://socket.io/docs/v4/faq/#usage-with-express-session
+    // This was not designed with typescript in mind so it shows that the types are incompatible
+    // @ts-ignore
+    sessionMiddleware(socket.request, {}, next);
+  });
+
+  app.set('trust proxy', 1);
+
+  app.use(helmet());
+  app.use(express.json());
+  app.use(sessionMiddleware);
+  app.use((req, res, next) => {
+    req.io = io;
+    next();
+  });
   const withCors = cors({
     credentials: true,
     origin: findConfig('WEBAPP_ORIGIN', ''),
@@ -97,7 +105,7 @@ const start = async () => {
 
   // This error handler must come after all other middleware so that errors in
   // all middlewares and request handlers are handled consistently.
-  await app.use(handleErrors);
+  app.use(handleErrors);
 
   server.listen(Number(port), host, () => {
     console.log(`api listening on ${host}:${port}`);

--- a/webapp/src/helpers/__tests__/useSocket.ts
+++ b/webapp/src/helpers/__tests__/useSocket.ts
@@ -10,7 +10,9 @@ describe('useSocket', () => {
     process.env.REACT_APP_API_ORIGIN = 'http://test.api/origin';
     mockIo.mockReturnValue({} as unknown as Socket);
     const socket1 = useSocket();
-    expect(mockIo).toHaveBeenCalledWith(process.env.REACT_APP_API_ORIGIN);
+    expect(mockIo).toHaveBeenCalledWith(process.env.REACT_APP_API_ORIGIN, {
+      withCredentials: true,
+    });
     const socket2 = useSocket();
     expect(socket1).toBe(socket2);
     expect(mockIo.mock.calls.length).toEqual(1);

--- a/webapp/src/helpers/useSocket.ts
+++ b/webapp/src/helpers/useSocket.ts
@@ -2,6 +2,9 @@ import { io, Socket } from 'socket.io-client';
 
 let socket: Socket;
 const useSocket = () =>
-  socket || (socket = io(String(process.env.REACT_APP_API_ORIGIN)));
+  socket ||
+  (socket = io(String(process.env.REACT_APP_API_ORIGIN), {
+    withCredentials: true,
+  }));
 
 export default useSocket;


### PR DESCRIPTION
## Proposed changes

- Convert the usage of `expressSession` into `sessionMiddleware` to be used by Socket.IO
- Socket.IO is able to access the principalId through the cookie headers after it's sent by the `useSocket` helper function
- Express route handler have access to Socket.IO instance

Resolves the last few tasks on #174 

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
