### PR TITLE
Send flyway config using stdin during deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,13 +41,11 @@ jobs:
           echo "$GITHUB_TOKEN" | ssh ${{ github.event.inputs.environment }} 'docker login ghcr.io --username ${{ github.actor }} --password-stdin'
       - name: Run database schema migrations
         run: |
-          cat >>./flyway.conf <<END
+          cat <<END | ssh ${{ github.event.inputs.environment }} 'docker run --rm --interactive --pull always ghcr.io/opentree-education/rhizone-lms_flyway:latest migrate'
           flyway.password=$FLYWAY_PASSWORD
           flyway.url=$FLYWAY_URL
           flyway.user=$FLYWAY_USER
           END
-          scp ./flyway.conf ${{ github.event.inputs.environment }}:~/flyway.conf
-          ssh ${{ github.event.inputs.environment }} 'docker run --rm --pull always -v $HOME/flyway.conf:/flyway/conf/flyway.conf ghcr.io/opentree-education/rhizone-lms_flyway:latest migrate; rm ~/flyway.conf'
       - name: Deploy services
         run: |
           cat docker-compose.production.yml | ssh production 'docker stack deploy --with-registry-auth --compose-file - rhizone-lms'

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,2 +1,2 @@
-FROM flyway/flyway:8
+FROM flyway/flyway:6
 COPY ./migration/ /flyway/sql/


### PR DESCRIPTION
## Proposed changes

Downgrade flyway to version 6, which is able to read config from stdin.

Send flyway config via stdin during deployment instead of uploading a config file.

Resolves #322.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
