### PR TITLE
Ignore types for socket.request for now; it breaks the build

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -5,7 +5,7 @@ import cors from 'cors';
 import { createClient as createRedisClient } from 'redis';
 import { createServer } from 'http';
 import express from 'express';
-import expressSession, { Session } from 'express-session';
+import expressSession from 'express-session';
 import helmet from 'helmet';
 import { Server } from 'socket.io';
 
@@ -27,12 +27,6 @@ import { findConfig } from './services/configService';
 declare module 'express-session' {
   interface Session {
     principalId: number;
-  }
-}
-
-declare module 'http' {
-  interface IncomingMessage {
-    session: Session;
   }
 }
 
@@ -62,6 +56,7 @@ const start = async () => {
 
   io.on('connection', socket => {
     socket.on('meeting:join', async meetingId => {
+      // @ts-ignore
       const { principalId } = socket.request.session;
       if (await participantExists(meetingId, principalId)) {
         socket.join(`meeting:${meetingId}`);

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -56,6 +56,9 @@ const start = async () => {
 
   io.on('connection', socket => {
     socket.on('meeting:join', async meetingId => {
+      // There was a type conflict when declaring types for socket.request that
+      // caused the build to break.
+      // See: https://github.com/OpenTree-Education/rhizone-lms/pull/328
       // @ts-ignore
       const { principalId } = socket.request.session;
       if (await participantExists(meetingId, principalId)) {


### PR DESCRIPTION
## Proposed changes

`ts-node` runs the tests just fine, but `tsc` breaks with the type that was defined.

https://github.com/OpenTree-Education/rhizone-lms/runs/5413941756?check_suite_focus=true

So, `@ts-ignore` to unblock the pipeline until we figure out what happened.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
