### PR TITLE
Revert "Ignore types for socket.request for now; it breaks the build"

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -5,7 +5,7 @@ import cors from 'cors';
 import { createClient as createRedisClient } from 'redis';
 import { createServer } from 'http';
 import express from 'express';
-import expressSession from 'express-session';
+import expressSession, { Session } from 'express-session';
 import helmet from 'helmet';
 import Rollbar from 'rollbar';
 import { Server } from 'socket.io';
@@ -28,6 +28,12 @@ import { findConfig } from './services/configService';
 declare module 'express-session' {
   interface Session {
     principalId: number;
+  }
+}
+
+declare module 'http' {
+  interface IncomingMessage {
+    session: Session;
   }
 }
 
@@ -67,10 +73,6 @@ const start = async () => {
 
   io.on('connection', socket => {
     socket.on('meeting:join', async meetingId => {
-      // There was a type conflict when declaring types for socket.request that
-      // caused the build to break.
-      // See: https://github.com/OpenTree-Education/rhizone-lms/pull/328
-      // @ts-ignore
       const { principalId } = socket.request.session;
       if (await participantExists(meetingId, principalId)) {
         socket.join(`meeting:${meetingId}`);

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -5,7 +5,7 @@ import cors from 'cors';
 import { createClient as createRedisClient } from 'redis';
 import { createServer } from 'http';
 import express from 'express';
-import expressSession, { Session } from 'express-session';
+import expressSession, { Session, SessionData } from 'express-session';
 import helmet from 'helmet';
 import Rollbar from 'rollbar';
 import { Server } from 'socket.io';
@@ -33,7 +33,7 @@ declare module 'express-session' {
 
 declare module 'http' {
   interface IncomingMessage {
-    session: Session;
+    session: Session & Partial<SessionData>;
   }
 }
 


### PR DESCRIPTION
Reverts OpenTree-Education/rhizone-lms#328 and fixes the issue that broke the build.

Original build output.

```
~/projects/rhizone-lms/api (revert-328-177-types-broke-the-build) $ yarn build
yarn run v1.22.17
$ tsc
node_modules/@types/express-serve-static-core/index.d.ts:369:18 - error TS2320: Interface 'Request<P, ResBody, ReqBody, ReqQuery, Locals>' cannot simultaneously extend types 'IncomingMessage' and 'Request'.
  Named property 'session' of types 'IncomingMessage' and 'Request' are not identical.

369 export interface Request<
                     ~~~~~~~


Found 1 error.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Fixed build output.

```
~/projects/rhizone-lms/api (revert-328-177-types-broke-the-build) $ yarn build
yarn run v1.22.17
$ tsc
✨  Done in 2.38s.
```

The problem was:

> Named property 'session' of types 'IncomingMessage' and 'Request' are not identical.

The type of the named property 'session' on the 'Request' type is defined here:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/express-session/index.d.ts#L27

This PR defines the named 'session' property on the 'IncomingMessage' type in our code to be identical to the one on 'Request'. 