### PR TITLE
Make all migrations run on Flyway 6

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,11 @@
+# `db`
+
+The `db` module contains SQL used by [Flyway](https://flywaydb.org/) to manage
+the schema of the database.
+
+## `db/tasks`
+
+The `tasks` directory contains one-off scripts that can be run against the
+database for various reasons. They are committed to the repo so that we can
+review them before they are run and record a history of tasks run against the
+production database.

--- a/db/migration/V007__backfill_journal_entry_reflections.sql
+++ b/db/migration/V007__backfill_journal_entry_reflections.sql
@@ -1,30 +1,30 @@
-CREATE PROCEDURE createReflectionsAndAssignToJournalEntries()
-BEGIN
-    loopLabel: LOOP
-        SET @countUnassignedJournalEntries = (
-            SELECT COUNT(*)
-                FROM journal_entries
-                WHERE reflection_id IS NULL
-        );
-        IF (@countUnassignedJournalEntries = 0) THEN
-            LEAVE loopLabel;
-        END IF;
-        INSERT INTO reflections (principal_id)
-            SELECT principal_id
-            FROM journal_entries
-            WHERE reflection_id IS NULL
-            ORDER BY journal_entries.id
-            LIMIT 1;
-        UPDATE journal_entries
-            SET reflection_id = LAST_INSERT_ID()
-            WHERE reflection_id IS NULL
-            ORDER BY journal_entries.id
-            LIMIT 1;
-    END LOOP loopLabel;
-END;
-
-CALL createReflectionsAndAssignToJournalEntries();
-
-DROP PROCEDURE createReflectionsAndAssignToJournalEntries;
+-- CREATE PROCEDURE createReflectionsAndAssignToJournalEntries()
+-- BEGIN
+--     loopLabel: LOOP
+--         SET @countUnassignedJournalEntries = (
+--             SELECT COUNT(*)
+--                 FROM journal_entries
+--                 WHERE reflection_id IS NULL
+--         );
+--         IF (@countUnassignedJournalEntries = 0) THEN
+--             LEAVE loopLabel;
+--         END IF;
+--         INSERT INTO reflections (principal_id)
+--             SELECT principal_id
+--             FROM journal_entries
+--             WHERE reflection_id IS NULL
+--             ORDER BY journal_entries.id
+--             LIMIT 1;
+--         UPDATE journal_entries
+--             SET reflection_id = LAST_INSERT_ID()
+--             WHERE reflection_id IS NULL
+--             ORDER BY journal_entries.id
+--             LIMIT 1;
+--     END LOOP loopLabel;
+-- END;
+--
+-- CALL createReflectionsAndAssignToJournalEntries();
+--
+-- DROP PROCEDURE createReflectionsAndAssignToJournalEntries;
 
 ALTER TABLE journal_entries MODIFY reflection_id BIGINT NOT NULL;

--- a/db/tasks/T001__update_migration_7_checksum.sql
+++ b/db/tasks/T001__update_migration_7_checksum.sql
@@ -1,0 +1,1 @@
+UPDATE `flyway_schema_history` SET `checksum` = -2145763896 WHERE `installed_rank` = 7;


### PR DESCRIPTION
## Proposed changes

In order to make it so that new developers can run all the migrations using the downgraded Flyway version, one of the migrations had to be updated. Changing a migration file updates the checksum of that file, which will cause validation of the schema to fail when Flyway runs in production.

A new `db/tasks` folder was created to manage one-off tasks to be run against the production database. A new task was created to update the checksum of the changed migration in production so that it will pass validation.

Resolves #325.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
