### PR TITLE
Make host.docker.internal available to nginx for Linux development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ services:
     depends_on:
       - api
       - webapp
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "80:80"
   redis:


### PR DESCRIPTION
A feature was added to Docker to allow Linux containers to resolve the host IP address: https://github.com/moby/moby/pull/40007

Aliasing the magic string `host-gateway` to the host name `host.docker.internal` which is made available by default in Docker for Mac and Docker for Windows. Now all 3 dev environments should behave the same.