### PR TITLE
Upon successful meeting note creation, socket message is emitted to the associated room

### DIFF
--- a/api/src/middleware/meetingsRouter.ts
+++ b/api/src/middleware/meetingsRouter.ts
@@ -105,6 +105,9 @@ meetingsRouter.post('/:id/notes', async (req, res, next) => {
     );
     return;
   }
+
+  req.io.to(`meeting:${meetingId}`).emit('meeting_note:created', meetingNote);
+
   res.status(201).json(itemEnvelope(meetingNote));
 });
 

--- a/api/src/middleware/routerTestUtils.ts
+++ b/api/src/middleware/routerTestUtils.ts
@@ -1,6 +1,9 @@
-import expressSession from 'express-session';
-import express, { NextFunction, Request, Response, Router } from 'express';
 import { agent, SuperAgentTest } from 'supertest';
+import { createServer } from 'http';
+import express, { NextFunction, Request, Response, Router } from 'express';
+import expressSession from 'express-session';
+import { findConfig } from './../services/configService';
+import { Server } from 'socket.io';
 
 const getPrincipalId = jest.fn();
 
@@ -12,14 +15,26 @@ export const sessionDestroyMock = jest.fn();
 
 export const createAppAgentForRouter = (router: Router): SuperAgentTest => {
   const app = express();
+
+  const server = createServer(app);
+  const io = new Server(server, {
+    cors: {
+      origin: [findConfig('WEBAPP_ORIGIN', '')],
+      credentials: true,
+    },
+  });
+
+  const sessionMiddleware = expressSession({
+    resave: true,
+    saveUninitialized: true,
+    secret: 'secret',
+  });
   app.use(express.json());
-  app.use(
-    expressSession({
-      resave: true,
-      saveUninitialized: true,
-      secret: 'secret',
-    })
-  );
+  app.use(sessionMiddleware);
+  app.use((req, res, next) => {
+    req.io = io;
+    next();
+  });
   app.use((req: Request, res: Response, next: NextFunction) => {
     req.session.destroy = sessionDestroyMock.mockImplementation(
       req.session.destroy

--- a/api/src/services/__tests__/meetingsService.ts
+++ b/api/src/services/__tests__/meetingsService.ts
@@ -145,12 +145,12 @@ describe('meetingsService', () => {
       const authoringParticipantId = 6;
       const createdAt = '2000-01-01 00:00:00';
       const meetingNote = {
-        meetingNoteId,
-        agendaOwningParticipantId,
-        authoringParticipantId,
-        sortOrder,
-        noteText,
-        createdAt,
+        id: meetingNoteId,
+        agenda_owning_participant_id: agendaOwningParticipantId,
+        authoring_participant_id: authoringParticipantId,
+        sort_order: sortOrder,
+        note_text: noteText,
+        created_at: createdAt,
       };
       mockQuery(
         'select `id` from `participants` where `meeting_id` = ? and `principal_id` = ?',

--- a/api/src/services/__tests__/meetingsService.ts
+++ b/api/src/services/__tests__/meetingsService.ts
@@ -135,65 +135,7 @@ describe('meetingsService', () => {
   });
 
   describe('createMeetingNote', () => {
-    it('should insert a meeting note with the authoring participant id of the given principal in the given meeting', async () => {
-      const meetingId = 2;
-      const principalId = 3;
-      const agendaOwningParticipantId = 4;
-      const noteText = '';
-      const sortOrder = 0;
-      const meetingNoteId = 5;
-      mockQuery(
-        'select `id` from `participants` where `meeting_id` = ? and `principal_id` = ?',
-        [meetingId, principalId],
-        [{ id: 6 }]
-      );
-      mockQuery(
-        'insert into `meeting_notes` (`agenda_owning_participant_id`, `authoring_participant_id`, `note_text`, `sort_order`) values (?, ?, ?, ?)',
-        [agendaOwningParticipantId, 6, noteText, sortOrder],
-        [meetingNoteId]
-      );
-      mockQuery(
-        'select `id`, `agenda_owning_participant_id`, `authoring_participant_id`, `sort_order`, `note_text`, `created_at` from `meeting_notes` where `id` = ?',
-        [meetingNoteId],
-        [{ id: 5 }]
-      );
-      expect(
-        await createMeetingNote(
-          meetingId,
-          principalId,
-          agendaOwningParticipantId,
-          noteText,
-          sortOrder
-        )
-      ).toEqual({ id: meetingNoteId });
-    });
-    it('should resolve to null if no meeting note id exists', async () => {
-      const meetingId = 2;
-      const principalId = 3;
-      const agendaOwningParticipantId = 4;
-      const noteText = '';
-      const sortOrder = 0;
-      mockQuery(
-        'select `id` from `participants` where `meeting_id` = ? and `principal_id` = ?',
-        [meetingId, principalId],
-        [{ id: 6 }]
-      );
-      mockQuery(
-        'insert into `meeting_notes` (`agenda_owning_participant_id`, `authoring_participant_id`, `note_text`, `sort_order`) values (?, ?, ?, ?)',
-        [agendaOwningParticipantId, 6, noteText, sortOrder],
-        []
-      );
-      expect(
-        await createMeetingNote(
-          meetingId,
-          principalId,
-          agendaOwningParticipantId,
-          noteText,
-          sortOrder
-        )
-      ).toEqual(null);
-    });
-    it('should return a meetingNote object from a given meeting note id', async () => {
+    it('should insert a meeting note with the authoring participant id of the given principal in the given meeting and returns a complete meeting note object', async () => {
       const meetingId = 2;
       const principalId = 3;
       const agendaOwningParticipantId = 4;
@@ -201,7 +143,7 @@ describe('meetingsService', () => {
       const sortOrder = 0;
       const meetingNoteId = 5;
       const authoringParticipantId = 6;
-      const createdAt = '';
+      const createdAt = '2000-01-01 00:00:00';
       const meetingNote = {
         meetingNoteId,
         agendaOwningParticipantId,
@@ -234,6 +176,32 @@ describe('meetingsService', () => {
           sortOrder
         )
       ).toEqual(meetingNote);
+    });
+    it('should resolve to null when the query to insert a meeting note responds with an empty array', async () => {
+      const meetingId = 2;
+      const principalId = 3;
+      const agendaOwningParticipantId = 4;
+      const noteText = '';
+      const sortOrder = 0;
+      mockQuery(
+        'select `id` from `participants` where `meeting_id` = ? and `principal_id` = ?',
+        [meetingId, principalId],
+        [{ id: 6 }]
+      );
+      mockQuery(
+        'insert into `meeting_notes` (`agenda_owning_participant_id`, `authoring_participant_id`, `note_text`, `sort_order`) values (?, ?, ?, ?)',
+        [agendaOwningParticipantId, 6, noteText, sortOrder],
+        []
+      );
+      expect(
+        await createMeetingNote(
+          meetingId,
+          principalId,
+          agendaOwningParticipantId,
+          noteText,
+          sortOrder
+        )
+      ).toEqual(null);
     });
     it('should return a null value if a meetingNote cannot be found from the meeting note id', async () => {
       const meetingId = 2;

--- a/api/src/services/__tests__/meetingsService.ts
+++ b/api/src/services/__tests__/meetingsService.ts
@@ -152,6 +152,11 @@ describe('meetingsService', () => {
         [agendaOwningParticipantId, 6, noteText, sortOrder],
         [meetingNoteId]
       );
+      mockQuery(
+        'select `id`, `agenda_owning_participant_id`, `authoring_participant_id`, `sort_order`, `note_text`, `created_at` from `meeting_notes` where `id` = ?',
+        [meetingNoteId],
+        [{ id: 5 }]
+      );
       expect(
         await createMeetingNote(
           meetingId,
@@ -162,7 +167,106 @@ describe('meetingsService', () => {
         )
       ).toEqual({ id: meetingNoteId });
     });
-
+    it('should resolve to null if no meeting note id exists', async () => {
+      const meetingId = 2;
+      const principalId = 3;
+      const agendaOwningParticipantId = 4;
+      const noteText = '';
+      const sortOrder = 0;
+      mockQuery(
+        'select `id` from `participants` where `meeting_id` = ? and `principal_id` = ?',
+        [meetingId, principalId],
+        [{ id: 6 }]
+      );
+      mockQuery(
+        'insert into `meeting_notes` (`agenda_owning_participant_id`, `authoring_participant_id`, `note_text`, `sort_order`) values (?, ?, ?, ?)',
+        [agendaOwningParticipantId, 6, noteText, sortOrder],
+        []
+      );
+      expect(
+        await createMeetingNote(
+          meetingId,
+          principalId,
+          agendaOwningParticipantId,
+          noteText,
+          sortOrder
+        )
+      ).toEqual(null);
+    });
+    it('should return a meetingNote object from a given meeting note id', async () => {
+      const meetingId = 2;
+      const principalId = 3;
+      const agendaOwningParticipantId = 4;
+      const noteText = '';
+      const sortOrder = 0;
+      const meetingNoteId = 5;
+      const authoringParticipantId = 6;
+      const createdAt = '';
+      const meetingNote = {
+        meetingNoteId,
+        agendaOwningParticipantId,
+        authoringParticipantId,
+        sortOrder,
+        noteText,
+        createdAt,
+      };
+      mockQuery(
+        'select `id` from `participants` where `meeting_id` = ? and `principal_id` = ?',
+        [meetingId, principalId],
+        [{ id: 6 }]
+      );
+      mockQuery(
+        'insert into `meeting_notes` (`agenda_owning_participant_id`, `authoring_participant_id`, `note_text`, `sort_order`) values (?, ?, ?, ?)',
+        [agendaOwningParticipantId, 6, noteText, sortOrder],
+        [meetingNoteId]
+      );
+      mockQuery(
+        'select `id`, `agenda_owning_participant_id`, `authoring_participant_id`, `sort_order`, `note_text`, `created_at` from `meeting_notes` where `id` = ?',
+        [meetingNoteId],
+        [meetingNote]
+      );
+      expect(
+        await createMeetingNote(
+          meetingId,
+          principalId,
+          agendaOwningParticipantId,
+          noteText,
+          sortOrder
+        )
+      ).toEqual(meetingNote);
+    });
+    it('should return a null value if a meetingNote cannot be found from the meeting note id', async () => {
+      const meetingId = 2;
+      const principalId = 3;
+      const agendaOwningParticipantId = 4;
+      const noteText = '';
+      const sortOrder = 0;
+      const meetingNoteId = 5;
+      mockQuery(
+        'select `id` from `participants` where `meeting_id` = ? and `principal_id` = ?',
+        [meetingId, principalId],
+        [{ id: 6 }]
+      );
+      mockQuery(
+        'insert into `meeting_notes` (`agenda_owning_participant_id`, `authoring_participant_id`, `note_text`, `sort_order`) values (?, ?, ?, ?)',
+        [agendaOwningParticipantId, 6, noteText, sortOrder],
+        [meetingNoteId]
+      );
+      mockQuery(
+        'select `id`, `agenda_owning_participant_id`, `authoring_participant_id`, `sort_order`, `note_text`, `created_at` from `meeting_notes` where `id` = ?',
+        [meetingNoteId],
+        []
+      );
+      expect(
+        await createMeetingNote(
+          meetingId,
+          principalId,
+          agendaOwningParticipantId,
+          noteText,
+          sortOrder
+        )
+      ).toEqual(null);
+    });
     it('should resolve to null if the given principal id and meeting id do not refer to an existing participant', async () => {
       const meetingId = 2;
       const principalId = 3;

--- a/api/src/services/meetingsService.ts
+++ b/api/src/services/meetingsService.ts
@@ -102,7 +102,22 @@ export const createMeetingNote = async (
     note_text: noteText,
     sort_order: sortOrder,
   });
-  return { id };
+  if (!id) {
+    return null;
+  }
+  const [meetingNote] = await db('meeting_notes')
+    .select(
+      'id',
+      'agenda_owning_participant_id',
+      'authoring_participant_id',
+      'sort_order',
+      'note_text',
+      'created_at'
+    )
+    .where({
+      id,
+    });
+  return meetingNote || null;
 };
 
 export const participantExists = async (


### PR DESCRIPTION
## Proposed changes

- When a meeting note is successfully created, it will emit a socket message to the room associated with the meeting. 
- Add test cases in `meetingService` to test for new query data and null values

<img width="434" alt="image" src="https://user-images.githubusercontent.com/16721486/157323490-ab6a9fa3-5766-47e1-ac19-b4fc2c2c27c1.png">
Resolves #175 

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
