### PR TITLE
Meetings service changed to sort agenda items before action items

### DIFF
--- a/api/src/services/__tests__/meetingsService.ts
+++ b/api/src/services/__tests__/meetingsService.ts
@@ -44,7 +44,7 @@ describe('meetingsService', () => {
         [{ id: meetingId, starts_at: startsAt }]
       );
       mockQuery(
-        'select `meeting_notes`.`id` as `id`, `note_text`, `sort_order`, `authoring_participant_id`, `agenda_owning_participant_id` from `meeting_notes` inner join `participants` on `participants`.`id` = `meeting_notes`.`authoring_participant_id` where `participants`.`meeting_id` = ? order by `agenda_owning_participant_id` asc, `sort_order` asc, `meeting_notes`.`created_at` asc',
+        'select `meeting_notes`.`id` as `id`, `note_text`, `sort_order`, `authoring_participant_id`, `agenda_owning_participant_id` from `meeting_notes` inner join `participants` on `participants`.`id` = `meeting_notes`.`authoring_participant_id` where `participants`.`meeting_id` = ? order by `agenda_owning_participant_id is null` asc, `agenda_owning_participant_id` asc, `sort_order` asc, `meeting_notes`.`created_at` asc',
         [meetingId],
         meetingNotes
       );

--- a/api/src/services/meetingsService.ts
+++ b/api/src/services/meetingsService.ts
@@ -39,6 +39,7 @@ export const findMeeting = async (
       )
       .where({ 'participants.meeting_id': meetingId })
       .orderBy([
+        'agenda_owning_participant_id is null',
         'agenda_owning_participant_id',
         'sort_order',
         'meeting_notes.created_at',


### PR DESCRIPTION
## Proposed changes

This PR proposes to list agenda_owning_participant_id nulls last 

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [ ] Are there screenshots for UI changes?
