### PR TITLE
Renew TLS certificates on production automatically

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,4 +48,4 @@ jobs:
           END
       - name: Deploy services
         run: |
-          cat docker-compose.production.yml | ssh production 'docker stack deploy --with-registry-auth --compose-file - rhizone-lms'
+          cat docker-compose.production.yml | ssh ${{ github.event.inputs.environment }} 'docker stack deploy --with-registry-auth --compose-file - rhizone-lms'

--- a/.github/workflows/renew_tls_certificates.yml
+++ b/.github/workflows/renew_tls_certificates.yml
@@ -2,8 +2,8 @@ name: Renew TLS Certificates
 
 on:
   schedule:
-# Every Sunday at 08:00
-    - cron: '0 8 * * 0'
+# Every Monday at 17:00 UTC, 09:00 PST (-08:00)
+    - cron: '0 17 * * 1'
 
 jobs:
   run_certbot_renew:

--- a/.github/workflows/renew_tls_certificates.yml
+++ b/.github/workflows/renew_tls_certificates.yml
@@ -1,0 +1,33 @@
+name: Renew TLS Certificates
+
+on:
+  schedule:
+# Every Sunday at 08:00
+    - cron: '0 8 * * 0'
+
+jobs:
+  run_certbot_renew:
+    name: Run certbot renew on production
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Configure ssh
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$SSH_KEY" > ~/.ssh/production.key
+          chmod 600 ~/.ssh/production.key
+          cat >>~/.ssh/config <<END
+          Host production
+            HostName $SSH_HOST
+            User $SSH_USER
+            IdentityFile ~/.ssh/production.key
+          END
+          ssh-keyscan -H $SSH_HOST >> ~/.ssh/known_hosts
+      - name: Renew certificates and redeploy
+        run: |
+          ssh production docker service rm rhizone-lms_nginx
+          ssh production certbot renew
+          echo "$GITHUB_TOKEN" | ssh production docker login ghcr.io --username ${{ github.actor }} --password-stdin
+          cat docker-compose.production.yml | ssh production docker stack deploy --with-registry-auth --compose-file - rhizone-lms


### PR DESCRIPTION
## Proposed changes

Every Sunday at 08:00, this new workflow stops the nginx service on production, runs `certbot renew`, then redeploys the production stack, which starts nginx back up.

Resolves #251.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [ ] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
