### PR TITLE
Add orderBy to meetingNotes query so action items show up last

### DIFF
--- a/api/src/services/__tests__/meetingsService.ts
+++ b/api/src/services/__tests__/meetingsService.ts
@@ -44,7 +44,7 @@ describe('meetingsService', () => {
         [{ id: meetingId, starts_at: startsAt }]
       );
       mockQuery(
-        'select `meeting_notes`.`id` as `id`, `note_text`, `sort_order`, `authoring_participant_id`, `agenda_owning_participant_id` from `meeting_notes` inner join `participants` on `participants`.`id` = `meeting_notes`.`authoring_participant_id` where `participants`.`meeting_id` = ? order by `agenda_owning_participant_id` asc, `sort_order` asc, `meeting_notes`.`created_at` asc',
+        'select `meeting_notes`.`id` as `id`, `note_text`, `sort_order`, `authoring_participant_id`, `agenda_owning_participant_id` from `meeting_notes` inner join `participants` on `participants`.`id` = `meeting_notes`.`authoring_participant_id` where `participants`.`meeting_id` = ? order by agenda_owning_participant_id is null, `agenda_owning_participant_id` asc, `sort_order` asc, `meeting_notes`.`created_at` asc',
         [meetingId],
         meetingNotes
       );

--- a/api/src/services/meetingsService.ts
+++ b/api/src/services/meetingsService.ts
@@ -38,6 +38,7 @@ export const findMeeting = async (
         'meeting_notes.authoring_participant_id'
       )
       .where({ 'participants.meeting_id': meetingId })
+      .orderByRaw('agenda_owning_participant_id is null')
       .orderBy([
         'agenda_owning_participant_id',
         'sort_order',


### PR DESCRIPTION
## Proposed changes

Changes the Meeting Notes query to order agenda items with `agenda_owning_participant_id` as`null` last.

Resolves #316.

<img width="500" alt="Screen Shot 2022-03-10 at 1 19 56 PM" src="https://user-images.githubusercontent.com/82873669/157747886-0bdeecf4-2528-4ae6-bad2-216a6a6b0956.png">

## Checklist

- [X] Are the issues being addressed linked to this PR?
- [X] Do all commit messages start with the issue number?
- [X] Are all code changes sufficiently tested?
- [X] Are there screenshots for UI changes?
