### PR TITLE
#357 Improve Flyway Reliability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,11 +27,17 @@ services:
     platform: linux/x86_64
     ports:
       - "3306:3306"
+    healthcheck:
+      test: mysql ${MYSQL_DATABASE} --user=${MYSQL_USER} --password='${MYSQL_PASSWORD}' --silent --execute "SELECT 1;"
+      interval: 10s
+      timeout: 10s
+      retries: 12
   flyway:
     build: ./db/
     command: migrate
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
     environment:
       - FLYWAY_CONNECT_RETRIES=10
       - FLYWAY_PASSWORD=${MYSQL_PASSWORD}


### PR DESCRIPTION
This adds a health check to the MySQL container, and it modifies the Flyway container to tell Docker to wait until the MySQL container is *listening* before starting the Flyway container.

## Proposed changes

I'm proposing to modify the `docker-compose.yml` file we all use to bring up our local development environments to delay launching the Flyway container until the MySQL container is considered 'healthy'; that is, when the MySQL container is listening for incoming connections. This should improve the reliability of the database migrations immensely, as long as the MySQL daemon can start listening within 120 seconds (two minutes) from container start and respond to the health check in a way that Docker understands.

If and only if that's the case will Docker execute the Flyway container to perform the database migrations. If it can't contact MySQL within 120 seconds, `docker-compose` will error out instead of continuing to bring up the development environment.

This resolves issue #357.

## Testing

I tested this in both my macOS virtual machine and my Windows 11 virtual machine to success, but I'd like others on the team in their different environments to check to see if it breaks anything on their end.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes? (Does not apply.)
