### PR TITLE
Create route to fetch categories with their competencies

### DIFF
--- a/api/src/middleware/__tests__/competenciesRouter.ts
+++ b/api/src/middleware/__tests__/competenciesRouter.ts
@@ -15,6 +15,10 @@ const mockCountCompetencies = jest.mocked(countCompetencies);
 const mockCreateCompetency = jest.mocked(createCompetency);
 const mockListCompetencies = jest.mocked(listCompetencies);
 const mockUpdateCompetency = jest.mocked(updateCompetency);
+const mockListCategories = jest.mocked(listCategories);
+const mockGetAllCompetenciesByCategory = jest.mocked(
+  getAllCompetenciesByCategory
+);
 
 describe('competenciesRouter', () => {
   const appAgent = createAppAgentForRouter(competenciesRouter);
@@ -179,6 +183,63 @@ describe('competenciesRouter', () => {
           description: 'test',
         })
         .expect(500, done);
+    });
+  });
+
+  describe('GET /categories', () => {
+    it('should respond with all categories and their competencies in an array inside the category object', done => {
+      const categories = [
+        {
+          id: 2,
+          label: 'categoryLabel',
+          description: 'categoryDescription',
+        },
+      ];
+      const competencies = [
+        {
+          id: 3,
+          label: 'label',
+          description: 'description',
+          category_id: 2,
+        },
+        {
+          id: 4,
+          label: 'another label',
+          description: 'another description',
+          category_id: 2,
+        },
+      ];
+      const categoriesCount = categories.length;
+      const categoriesWithCompetencies = categories.map(category => {
+        return { ...category, competencies };
+      });
+
+      mockListCategories.mockResolvedValue(categories);
+      mockGetAllCompetenciesByCategory.mockResolvedValue(competencies);
+
+      appAgent
+        .get('/categories')
+        .expect(
+          200,
+          collectionEnvelope(categoriesWithCompetencies, categoriesCount),
+          err => {
+            expect(mockListCategories).toHaveBeenCalled();
+            expect(mockGetAllCompetenciesByCategory).toHaveBeenCalledWith(2);
+            done(err);
+          }
+        );
+    });
+
+    it('should respond with an internal server error if an error was thrown while listing categories', done => {
+      mockListCategories.mockRejectedValue(new Error());
+      mockGetAllCompetenciesByCategory.mockResolvedValue([]);
+      appAgent.get('/').expect(500, done);
+    });
+
+    it('should respond with an internal server error if an error was thrown while getting all competencies by category', done => {
+      mockListCategories.mockRejectedValue([]);
+      mockGetAllCompetenciesByCategory.mockResolvedValue(new Error());
+      appAgent.get('/').expect(500, done);
     });
   });
 });

--- a/api/src/middleware/__tests__/competenciesRouter.ts
+++ b/api/src/middleware/__tests__/competenciesRouter.ts
@@ -5,6 +5,8 @@ import {
   listCompetencies,
   createCompetency,
   updateCompetency,
+  getAllCompetenciesByCategory,
+  listCategories,
 } from '../../services/competenciesService';
 import { createAppAgentForRouter, mockPrincipalId } from '../routerTestUtils';
 import competenciesRouter from '../competenciesRouter';
@@ -233,13 +235,20 @@ describe('competenciesRouter', () => {
     it('should respond with an internal server error if an error was thrown while listing categories', done => {
       mockListCategories.mockRejectedValue(new Error());
       mockGetAllCompetenciesByCategory.mockResolvedValue([]);
-      appAgent.get('/').expect(500, done);
+      appAgent.get('/categories').expect(500, done);
     });
 
     it('should respond with an internal server error if an error was thrown while getting all competencies by category', done => {
-      mockListCategories.mockRejectedValue([]);
-      mockGetAllCompetenciesByCategory.mockResolvedValue(new Error());
-      appAgent.get('/').expect(500, done);
+      const categories = [
+        {
+          id: 2,
+          label: 'categoryLabel',
+          description: 'categoryDescription',
+        },
+      ];
+      mockListCategories.mockResolvedValue(categories);
+      mockGetAllCompetenciesByCategory.mockRejectedValue(new Error());
+      appAgent.get('/categories').expect(500, done);
     });
   });
 });

--- a/api/src/middleware/competenciesRouter.ts
+++ b/api/src/middleware/competenciesRouter.ts
@@ -93,4 +93,28 @@ competenciesRouter.put('/:id', async (req, res, next) => {
   res.json(itemEnvelope({ id: competencyId }));
 });
 
+competenciesRouter.get('/categories', async (req, res, next) => {
+  let categoriesWithCompetencies;
+  try {
+    const categories = await listCategories(); // TODO
+
+    categoriesWithCompetencies = await Promise.all(
+      categories.map(async category => {
+        // TODO
+        const competencies = await getAllCompetenciesByCategory(category.id);
+        return { ...category, competencies };
+      })
+    );
+  } catch (error) {
+    next(error);
+    return;
+  }
+  res.json(
+    collectionEnvelope(
+      categoriesWithCompetencies,
+      categoriesWithCompetencies.length
+    )
+  );
+});
+
 export default competenciesRouter;

--- a/api/src/middleware/competenciesRouter.ts
+++ b/api/src/middleware/competenciesRouter.ts
@@ -8,6 +8,8 @@ import {
   createCompetency,
   listCompetencies,
   updateCompetency,
+  getAllCompetenciesByCategory,
+  listCategories,
 } from '../services/competenciesService';
 import { parsePaginationParams } from './paginationParamsMiddleware';
 
@@ -96,11 +98,10 @@ competenciesRouter.put('/:id', async (req, res, next) => {
 competenciesRouter.get('/categories', async (req, res, next) => {
   let categoriesWithCompetencies;
   try {
-    const categories = await listCategories(); // TODO
+    const categories = await listCategories();
 
     categoriesWithCompetencies = await Promise.all(
       categories.map(async category => {
-        // TODO
         const competencies = await getAllCompetenciesByCategory(category.id);
         return { ...category, competencies };
       })


### PR DESCRIPTION
## Proposed changes

Closes #374 
This PR creates an API route at `/competencies/categories` that returns all categories in the database in an array, with each category object containing an array of their competencies. This route can be used on the frontend to render the competency categories and each competency in each category on the visualization table. 

This is a screenshot of the returned categories and competencies in JSON:
<img width="1270" alt="Screen Shot 2022-06-28 at 4 09 17 PM" src="https://user-images.githubusercontent.com/67711077/176276349-dcd791f3-674b-441b-a258-8dd0c70b7a95.png">

Here is a screenshot of the passing tests:
<img width="747" alt="Screen Shot 2022-06-28 at 4 08 39 PM" src="https://user-images.githubusercontent.com/67711077/176276403-8c3b839b-746b-4ea9-9ad3-b1bf6c033ba2.png">

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [ ] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
