### PR TITLE
Add migration file to create categories_questionnaires table

### DIFF
--- a/db/migration/V018__create_categories_questionnaires_table.sql
+++ b/db/migration/V018__create_categories_questionnaires_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE categories_questionnaires (
+  id BIGINT NOT NULL AUTO_INCREMENT, 
+  category_id BIGINT NOT NULL,
+  questionnaire_id BIGINT NOT NULL,
+  PRIMARY KEY (id),
+  INDEX categories_questionnaires_category_id (category_id),
+  FOREIGN KEY (category_id) REFERENCES categories(id),
+  INDEX categories_questionnaires_questionnaire_id (questionnaire_id),
+  FOREIGN KEY (questionnaire_id) REFERENCES questionnaires(id)
+);


### PR DESCRIPTION
## Proposed changes

Closes #404 
This creates a new join table for categories and questionnaires. 
Here is the migration file running:
<img width="723" alt="flyway migration" src="https://user-images.githubusercontent.com/67711077/176749458-daf9069d-68bb-46df-b37c-b9fc3cb13523.png">

And here is a screenshot of the new table in Sequel Ace:
<img width="593" alt="Screen Shot 2022-06-30 at 2 14 38 PM" src="https://user-images.githubusercontent.com/67711077/176749675-5645830c-bbeb-4fb7-bb90-d5a9038e37b3.png">

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
