### PR TITLE
375 Add a route that renders the list of reflections

### DIFF
--- a/api/src/middleware/reflectionsRouter.ts
+++ b/api/src/middleware/reflectionsRouter.ts
@@ -28,6 +28,23 @@ reflectionsRouter.get('/', parsePaginationParams(), async (req, res, next) => {
   res.json(collectionEnvelope(reflections, reflectionsCount));
 });
 
+reflectionsRouter.get('/competencies', parsePaginationParams(), async (req, res, next) => {
+  const { principalId } = req.session;
+  const { limit, offset } = req.pagination;
+  let reflections;
+  let reflectionsCount;
+  try {
+    [reflections, reflectionsCount] = await Promise.all([
+      listReflections(principalId, limit, offset),
+      countReflections(principalId),
+    ]);
+  } catch (err) {
+    next(err);
+    return;
+  }
+  res.json(collectionEnvelope(reflections, reflectionsCount));
+});
+
 reflectionsRouter.post('/', async (req, res, next) => {
   const { principalId } = req.session;
   const { raw_text: rawText, selected_option_ids: selectedOptionIds } =


### PR DESCRIPTION
## Proposed changes

This route '/reflections/competencies' renders the list of competency reflections on the front-end, and it's shown as a competency rating.

## Screenshots

<img width="400" alt="Screen Shot 2022-06-30 at 16 36 46" src="https://user-images.githubusercontent.com/86091962/176795634-39708b4e-3f8c-4753-a3c1-ba71c0251c6d.png">


<img width="400" alt="Screen Shot 2022-06-30 at 16 34 55" src="https://user-images.githubusercontent.com/86091962/176795727-f2cb2744-6040-4c55-8c9a-7b1999b93e63.png">


## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
