### PR TITLE
#410 Increase network timeout value to 10 minutes

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:16.13-alpine AS build
 WORKDIR /app/
 COPY ./ ./
-RUN yarn install --ignore-platform --frozen-lockfile
+RUN yarn install --ignore-platform --frozen-lockfile --network-timeout 600000
 RUN yarn build
 
 FROM node:16.13-alpine
@@ -9,5 +9,5 @@ WORKDIR /app/
 COPY --from=build /app/dist/ ./dist/
 COPY --from=build /app/package.json /app/yarn.lock ./
 ENV NODE_ENV=production
-RUN yarn install --frozen-lockfile && yarn cache clean
+RUN yarn install --frozen-lockfile --network-timeout 600000 && yarn cache clean
 CMD yarn start

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -5,7 +5,7 @@ ARG REACT_APP_ROLLBAR_ACCESS_TOKEN
 ENV REACT_APP_ROLLBAR_ACCESS_TOKEN $REACT_APP_ROLLBAR_ACCESS_TOKEN
 WORKDIR /app/
 COPY ./ ./
-RUN yarn install --ignore-platform --frozen-lockfile
+RUN yarn install --ignore-platform --frozen-lockfile --network-timeout 600000
 RUN yarn build
 
 FROM nginx:1.21-alpine


### PR DESCRIPTION
Resolves #410.

This should improve quality of life for users with slower internet connections, but should have no impact on any others. Previously discussed with Davey.

## Proposed changes

This modifies the Dockerfile for each of the affected docker images (`api` and `webapp`) to increase Yarn's network timeout during install to 10 minutes (600,000 milliseconds).

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
