### PR TITLE
#413 Insert default curriculum, including activities

### DIFF
--- a/db/migration/V020__insert_default_activities.sql
+++ b/db/migration/V020__insert_default_activities.sql
@@ -1,0 +1,14 @@
+INSERT INTO questionnaires () VALUES
+  ();
+SET @questionnaire_id = LAST_INSERT_ID();
+INSERT INTO settings (property, content, category) VALUES
+  ('default_questionnaire_id', CAST(@questionnaire_id AS CHAR), 'webapp');
+INSERT INTO prompts (label, query_text, sort_order, questionnaire_id) VALUES
+  ('Outlook', 'How are you feeling about your current endeavours?', 1, @questionnaire_id);
+SET @prompt_id = LAST_INSERT_ID();
+INSERT INTO options (label, numeric_value, sort_order, prompt_id) VALUES
+  ('Very discouraged', -2, 1, @prompt_id),
+  ('A little discouraged', -1, 2, @prompt_id),
+  ('I don’t know', 0, 3, @prompt_id),
+  ('A little hopeful', 1, 4, @prompt_id),
+  ('Very hopeful', 2, 5, @prompt_id);

--- a/db/migration/V020__insert_default_activities.sql
+++ b/db/migration/V020__insert_default_activities.sql
@@ -3,123 +3,124 @@ INSERT INTO curriculums (principal_id, title) VALUES
 
 INSERT INTO activities (title, description_text, curriculum_week, curriculum_day, start_time, end_time, duration, activity_type_id, curriculum_id) VALUES
   --Week 1: Day 1
-  ('Morning standup', '', 1, 1, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Self Introduction', 'Getting to know each other', 1, 1, '11:10:00', '12:00:00', 50, 1, 1),
+  ('Morning Standup', '', 1, 1, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Self-introduction', 'Get to know each other.', 1, 1, '11:10:00', '12:00:00', 50, 1, 1),
   --Week 1: Day 2
-  ('Self assignment', '', 1, 2, NULL, NULL, NULL, 2, 1),
-  ('PMP inroduction', 'An overview of the project and technological environment', 1, 2, '11:00:00', '12:00:00', 60, 1, 1),
-  ('Set up local copy of repository', 'Clone the repository and follow the instructions to set it up on your development machine.', 1, 2, NULL, NULL, NULL, 2, 1),  
+  ('Self-assessment', '', 1, 2, NULL, NULL, NULL, 2, 1),
+  ('PMP Inroduction', 'Overview of the project and technological environment.', 1, 2, '11:00:00', '12:00:00', 60, 1, 1),
+  ('Set up Local Copy of Repository', 'Clone the repository and follow the instructions to set it up on your development machine.', 1, 2, NULL, NULL, NULL, 2, 1),  
   --Week 1: Day 3
-  ('Morning standup', 'Check the progress', 1, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Product Brief', 'Go through the Product Brief', 1, 3, '12:10:00', '13:00:00', 50, 1, 1),
+  ('Morning Standup', 'Check progress.', 1, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Product Brief', 'Go through the Product Brief.', 1, 3, '12:10:00', '13:00:00', 50, 1, 1),
   --Week 1: Day 4
-  ('Game time', '', 1, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Product Specification', 'Go through the Product Specification', 1, 4, '11:00:00', '13:00:00', 120, 1, 1),
+  ('Game Time', '', 1, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Product Specification', 'Go through the Product Specification.', 1, 4, '11:00:00', '13:00:00', 120, 1, 1),
   --Week 1: Day 5
   ('Self-reflection', '', 1, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('Data flow demostration', 'Go through the existing codes on the app', 1, 5, '11:05:00', '13:00:00', 115, 1, 1),
+  ('Data flow demostration', 'Go through the existing codes on the app.', 1, 5, '11:05:00', '13:00:00', 115, 1, 1),
   --Week 2: Day 1
-  ('Morning standu', '', 2, 1, '10:00:00', '11:00:00', 60, 3, 1), 
-  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design', 2, 1, NULL, NULL, NULL, 1, 1),
+  ('Morning Standup', '', 2, 1, '10:00:00', '11:00:00', 60, 3, 1), 
+  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 1, NULL, NULL, NULL, 1, 1),
   --Week 2: Day 2
-  ('Self assignment', '', 2, 2, NULL, NULL, NULL, 2, 1),
-  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design', 2, 2, NULL, NULL, NULL, 1, 1),
+  ('Self-assessment', '', 2, 2, NULL, NULL, NULL, 2, 1),
+  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 2, NULL, NULL, NULL, 1, 1),
   --Week 2: Day 3
-  ('Morning standup', 'Check the progress', 2, 3, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design', 2, 3, NULL, NULL, NULL, 1, 1),
+  ('Morning Standup', 'Check the progress', 2, 3, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 3, NULL, NULL, NULL, 1, 1),
   --Week 2: Day 4
-  ('Game time', '', 2, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design', 2, 4, NULL, NULL, NULL, 1, 1),
+  ('Game Time', '', 2, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 4, NULL, NULL, NULL, 1, 1),
   --Week 2: Day 5
   ('Self-reflection', '', 2, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('Prototyping Demo', 'Demostrate the prototype from each group', 2, 5, '11:10:00', '13:30:00', 140, 2, 1),
+  ('Prototyping Demo', 'Demostrate the prototype from each group.', 2, 5, '11:10:00', '13:30:00', 140, 2, 1),
   --Week 3: Day 1
-  ('Morning standup', '', 3, 1, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Github collaboration demo', '', 3, 1, '11:10:00', '12:00:00', 50, 1, 1),
+  ('Morning Standup', 'Plan the schedule for the week and assign tickets.', 3, 1, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Github Collaboration Demo', '', 3, 1, '11:10:00', '12:00:00', 50, 1, 1),
   --Week 3: Day 2
-  ('Self assignment', '', 3, 2, NULL, NULL, NULL, 2, 1),
-  ('Group working', 'Working on the ticket', 3, 2, '11:00:00','24:00:00', 780, 1, 1),
+  ('Self-assessment', '', 3, 2, NULL, NULL, NULL, 2, 1),
+  ('Collaborative Work Period', 'Work on a group ticket.', 3, 2, '11:00:00','24:00:00', 780, 1, 1),
   --Week 3: Day 3
-  ('Morning standup', 'Check the progress', 3, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Group working', 'Working on the ticket', 3, 3, '12:10:00','24:00:00', 780, 1, 1),
+  ('Morning Standup', 'Check the progress', 3, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Collaborative Work Period', 'Work on a group ticket.', 3, 3, '12:10:00','24:00:00', 780, 1, 1),
   --Week 3: Day 4
-  ('Game time', '', 3, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Group working', 'Working on the ticket', 3, 4, '10:40:00','24:00:00', 800, 1, 1),
+  ('Game Time', '', 3, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Collaborative Work Period', 'Work on a group ticket.', 3, 4, '10:40:00','24:00:00', 800, 1, 1),
   --Week 3: Day 5
   ('Self-reflection', '', 3, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('1:1 mentorship', '', 3, 5, '11:10:00', '13:10:00', 120, 4, 1),
+  ('One-on-one Mentorship Session', '', 3, 5, '11:10:00', '13:10:00', 120, 4, 1),
   --Week 4: Day 1
-  ('Morning standup', '', 4, 1, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Sprint Planing', 'Planing the schedule for the week and assigning tickets', 4, 1, '11:10:00', '12:00:00', 50, 1, 1), 
+  ('Morning Standup', '', 4, 1, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 4, 1, '11:10:00', '12:00:00', 50, 1, 1), 
   --Week 4: Day 2
-  ('Self assignment', '', 4, 2, NULL, NULL, NULL, 2, 1),
-  ('Working on the ticket', 'Working on the assigned ticket', 4, 2, '10:00:00','24:00:00', 840, 1, 1),
+  ('Self-assessment', '', 4, 2, NULL, NULL, NULL, 2, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 4, 2, '10:00:00','24:00:00', 840, 1, 1),
   --Week 4: Day 3
-  ('Morning standup', 'Check the progress', 4, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Working on the ticket', 'Working on the assigned ticket', 4, 3, '12:10:00','24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check the progress', 4, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 4, 3, '12:10:00','24:00:00', 710, 1, 1),
   --Week 4: Day 4
-  ('Game time', '', 4, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Working on the ticket', 'Working on the assigned ticket', 4, 4, '10:00:00','24:00:00', 840, 1, 1),
+  ('Game Time', '', 4, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 4, 4, '10:00:00','24:00:00', 840, 1, 1),
   --Week 4: Day 5
   ('Self reflection', '', 4, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('1:1 mentorship', '', 4, 5, '11:10:00', '13:10:00', 120, 4, 1),
+  ('One-on-one Mentorship Session', '', 4, 5, '11:10:00', '13:10:00', 120, 4, 1),
   --Week 5: Day 1
-  ('Morning standup', '', 5, 1, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Sprint Planing', 'Planing the schedule for the week and assigning tickets', 5, 1, '11:10:00', '12:00:00', 50, 1, 1), 
+  ('Morning Standup', '', 5, 1, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 5, 1, '11:10:00', '12:00:00', 50, 1, 1), 
   --Week 5: Day 2
-  ('Self assignment', '', 5, 2, NULL, NULL, NULL, 2, 1),
-  ('Working on the ticket', 'Working on the assigned ticket', 5, 2, '10:00:00','24:00:00', 840, 1, 1),
+  ('Self-assessment', '', 5, 2, NULL, NULL, NULL, 2, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 5, 2, '10:00:00','24:00:00', 840, 1, 1),
   --Week 5: Day 3 
-  ('Morning standup', 'Check the progress', 5, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Working on the ticket', 'Working on the assigned ticket', 5, 3, '12:10:00','24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check the progress', 5, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 5, 3, '12:10:00','24:00:00', 710, 1, 1),
   --Week 5: Day 4  
-  ('Game time', '', 5, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Working on the ticket', 'Working on the assigned ticket', 5, 4, '10:00:00','24:00:00', 840, 1, 1),
+  ('Game Time', '', 5, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 5, 4, '10:00:00','24:00:00', 840, 1, 1),
   --Week 5: Day 5  
   ('Self-reflection', '', 5, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('1:1 mentorship', '', 5, 5, '11:10:00', '13:10:00', 120, 4, 1),
+  ('One-on-one Mentorship Session', '', 5, 5, '11:10:00', '13:10:00', 120, 4, 1),
   --Week 6: Day 1  
-  ('Morning standup', '', 6, 1, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Sprint Planing', 'Planing the schedule for the week and assigning tickets', 6, 1, '11:10:00', '12:00:00', 50, 1, 1), 
+  ('Morning Standup', '', 6, 1, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 6, 1, '11:10:00', '12:00:00', 50, 1, 1), 
   --Week 6: Day 2 
-  ('Self assignment', '', 6, 2, NULL, NULL, NULL, 2, 1),
-  ('Working on the ticket', 'Working on the assigned ticket', 6, 2, '10:00:00','24:00:00', 840, 1, 1),
+  ('Self-assessment', '', 6, 2, NULL, NULL, NULL, 2, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 6, 2, '10:00:00','24:00:00', 840, 1, 1),
   --Week 6: Day 3 
-  ('Morning standup', 'Check the progress', 6, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Working on the ticket', 'Working on the assigned ticket', 6, 3, '12:10:00','24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check the progress', 6, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 6, 3, '12:10:00','24:00:00', 710, 1, 1),
   --Week 6: Day 4  
-  ('Game time', '', 6, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Working on the ticket', 'Working on the assigned ticket', 6, 2, '11:00:00','24:00:00', 780, 1, 1),
+  ('Game Time', '', 6, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 6, 2, '11:00:00','24:00:00', 780, 1, 1),
   --Week 6: Day 5  
   ('Self-reflection', '', 6, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('1:1 mentorship', '', 6, 5, '11:10:00', '13:10:00', 120, 4, 1),
+  ('One-on-one Mentorship Session', '', 6, 5, '11:10:00', '13:10:00', 120, 4, 1),
   --Week 7: Day 1  
-  ('Morning standup', '', 7, 1, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Sprint Planing', 'Planing the schedule for the week and assigning tickets', 7, 1, '11:10:00', '12:00:00', 50, 1, 1), 
+  ('Morning Standup', '', 7, 1, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 7, 1, '11:10:00', '12:00:00', 50, 1, 1), 
   --Week 7: Day 2 
-  ('Self assignment', '', 7, 2, NULL, NULL, NULL, 2, 1),
-  ('Working on the ticket', 'Working on the assigned ticket', 7, 2, '11:00:00','24:00:00', 780, 1, 1),
+  ('Self-assessment', '', 7, 2, NULL, NULL, NULL, 2, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 7, 2, '11:00:00','24:00:00', 780, 1, 1),
   --Week 7: Day 3
-  ('Morning standup', 'Check the progress', 7, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Working on the ticket', 'Working on the assigned ticket', 7, 3, '12:10:00','24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check the progress.', 7, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 7, 3, '12:10:00','24:00:00', 710, 1, 1),
   --Week 7: Day 4 
-  ('Game time', '', 7, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Working on the ticket', 'Working on the assigned ticket', 7, 4, '11:00:00','24:00:00', 780, 1, 1),
+  ('Game Time', '', 7, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 7, 4, '11:00:00','24:00:00', 780, 1, 1),
   --Week 7: Day 5  
   ('Self-reflection', '', 7, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('1:1 mentorship', '', 7, 5, '11:10:00', '13:10:00', 120, 4, 1),
+  ('One-on-one Mentorship Session', '', 7, 5, '11:10:00', '13:10:00', 120, 4, 1),
   --Week 8: Day 1  
-  ('Morning standup', '', 8, 1, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Sprint Planing', 'Planing the schedule for the week and assigning tickets', 8, 1, '11:10:00', '12:00:00', 50, 1, 1), 
+  ('Morning Standup', '', 8, 1, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 8, 1, '11:10:00', '12:00:00', 50, 1, 1), 
   --Week 8: Day 2 
-  ('Self assignment', '', 8, 2, NULL, NULL, NULL, 2, 1),
-  ('Working on the ticket', 'Working on the assigned ticket', 8, 2, '11:00:00','24:00:00', 780, 1, 1),
+  ('Self-assessment', '', 8, 2, NULL, NULL, NULL, 2, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 8, 2, '11:00:00','24:00:00', 780, 1, 1),
   --Week 8: Day 3  
-  ('Morning standup', 'Check the progress', 8, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Working on the ticket', 'Working on the assigned ticket', 8, 3, '12:10:00','24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check the progress', 8, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 8, 3, '12:10:00','24:00:00', 710, 1, 1),
   --Week 8: Day 4    
-  ('Game time', '', 8, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Working on the ticket', 'Working on the assigned ticket', 8, 4, '11:00:00','24:00:00', 780, 1, 1),
+  ('Game Time', '', 8, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 8, 4, '11:00:00','24:00:00', 780, 1, 1),
   --Week 8: Day 5   
   ('Self-reflection', '', 8, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('1:1 mentorship', '', 8, 5, '11:10:00', '13:10:00', 120, 4, 1);
+  ('One-on-one Mentorship Session', '', 8, 5, '11:10:00', '13:10:00', 120, 4, 1);
+

--- a/db/migration/V020__insert_default_activities.sql
+++ b/db/migration/V020__insert_default_activities.sql
@@ -1,5 +1,11 @@
+INSERT INTO principals () VALUES ();
+SET @principalId = LAST_INSERT_ID();
+
 INSERT INTO curriculums (principal_id, title) VALUES
-  (1, 'Professional Mentorship Program');
+  (@principalId, 'Professional Mentorship Program');
+
+INSERT INTO programs (principal_id, curriculum_id, title, start_date, end_date) VALUES 
+  (@principalId, 1, 'Cohort 4', '2022-10-24', '2022-12-16');
 
 INSERT INTO activities (title, description_text, curriculum_week, curriculum_day, start_time, end_time, duration, activity_type_id, curriculum_id) VALUES
   -- Week 1: Day 1

--- a/db/migration/V020__insert_default_activities.sql
+++ b/db/migration/V020__insert_default_activities.sql
@@ -3,129 +3,130 @@ SET @principalId = LAST_INSERT_ID();
 
 INSERT INTO curriculums (principal_id, title) VALUES
   (@principalId, 'Professional Mentorship Program');
+SET @curriculumId = LAST_INSERT_ID();
 
 INSERT INTO programs (principal_id, curriculum_id, title, start_date, end_date) VALUES 
-  (@principalId, 1, 'Cohort 4', '2022-10-24', '2022-12-16');
+  (@principalId, @curriculumId, 'Cohort 4', '2022-10-24', '2022-12-16');
 
 INSERT INTO activities (title, description_text, curriculum_week, curriculum_day, start_time, end_time, duration, activity_type_id, curriculum_id) VALUES
   -- Week 1: Day 1
-  ('Morning Standup', '', 1, 1, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Self-introduction', 'Get to know each other.', 1, 1, '11:10:00', '12:00:00', 50, 1, 1),
+  ('Morning Standup', '', 1, 1, '10:00:00', '11:00:00', 60, 3, @curriculumId),
+  ('Self-introduction', 'Get to know each other.', 1, 1, '11:10:00', '12:00:00', 50, 1, @curriculumId),
   -- Week 1: Day 2
-  ('Self-assessment', '', 1, 2, NULL, NULL, NULL, 2, 1),
-  ('PMP Introduction', 'Overview of the project and technological environment.', 1, 2, '11:00:00', '12:00:00', 60, 1, 1),
-  ('Set up Local Copy of Repository', 'Clone the repository and follow the instructions to set it up on your development machine.', 1, 2, NULL, NULL, NULL, 2, 1),  
+  ('Self-assessment', '', 1, 2, NULL, NULL, NULL, 2, @curriculumId),
+  ('PMP Introduction', 'Overview of the project and technological environment.', 1, 2, '11:00:00', '12:00:00', 60, 1, @curriculumId),
+  ('Set up Local Copy of Repository', 'Clone the repository and follow the instructions to set it up on your development machine.', 1, 2, NULL, NULL, NULL, 2, @curriculumId),  
   -- Week 1: Day 3
-  ('Morning Standup', 'Check progress.', 1, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Product Brief', 'Go through the Product Brief.', 1, 3, '12:10:00', '13:00:00', 50, 1, 1),
+  ('Morning Standup', 'Check progress.', 1, 3, '11:00:00', '12:00:00', 60, 3, @curriculumId),
+  ('Product Brief', 'Go through the Product Brief.', 1, 3, '12:10:00', '13:00:00', 50, 1, @curriculumId),
   -- Week 1: Day 4
-  ('Game Time', '', 1, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Product Specification', 'Go through the Product Specification.', 1, 4, '11:00:00', '13:00:00', 120, 1, 1),
+  ('Game Time', '', 1, 4, '10:00:00', '10:30:00', 30, 1, @curriculumId),
+  ('Product Specification', 'Go through the Product Specification.', 1, 4, '11:00:00', '13:00:00', 120, 1, @curriculumId),
   -- Week 1: Day 5
-  ('Self-reflection', '', 1, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('Data Flow Demonstration', 'Review the existing code structure from the perspective of how data flows through the app.', 1, 5, '11:05:00', '13:00:00', 115, 1, 1),
+  ('Self-reflection', '', 1, 5, '10:00:00', '11:00:00', 60, 4, @curriculumId),
+  ('Data Flow Demonstration', 'Review the existing code structure from the perspective of how data flows through the app.', 1, 5, '11:05:00', '13:00:00', 115, 1, @curriculumId),
   -- Week 2: Day 1
-  ('Morning Standup', '', 2, 1, '10:00:00', '11:00:00', 60, 3, 1), 
-  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 1, NULL, NULL, NULL, 1, 1),
+  ('Morning Standup', '', 2, 1, '10:00:00', '11:00:00', 60, 3, @curriculumId), 
+  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 1, NULL, NULL, NULL, 1, @curriculumId),
   -- Week 2: Day 2
-  ('Self-assessment', '', 2, 2, NULL, NULL, NULL, 2, 1),
-  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 2, NULL, NULL, NULL, 1, 1),
+  ('Self-assessment', '', 2, 2, NULL, NULL, NULL, 2, @curriculumId),
+  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 2, NULL, NULL, NULL, 1, @curriculumId),
   -- Week 2: Day 3
-  ('Morning Standup', 'Check progress.', 2, 3, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 3, NULL, NULL, NULL, 1, 1),
+  ('Morning Standup', 'Check progress.', 2, 3, '10:00:00', '11:00:00', 60, 3, @curriculumId),
+  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 3, NULL, NULL, NULL, 1, @curriculumId),
   -- Week 2: Day 4
-  ('Game Time', '', 2, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 4, NULL, NULL, NULL, 1, 1),
+  ('Game Time', '', 2, 4, '10:00:00', '10:30:00', 30, 1, @curriculumId),
+  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 4, NULL, NULL, NULL, 1, @curriculumId),
   -- Week 2: Day 5
-  ('Self-reflection', '', 2, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('Prototyping Demo', 'Demonstrate prototype of each team.', 2, 5, '11:10:00', '13:30:00', 140, 2, 1),
+  ('Self-reflection', '', 2, 5, '10:00:00', '11:00:00', 60, 4, @curriculumId),
+  ('Prototyping Demo', 'Demonstrate prototype of each team.', 2, 5, '11:10:00', '13:30:00', 140, 2, @curriculumId),
   -- Week 3: Day 1
-  ('Morning Standup', 'Plan the schedule for the week and assign tickets.', 3, 1, '10:00:00', '11:00:00', 60, 3, 1),
-  ('GitHub Collaboration Demo', '', 3, 1, '11:10:00', '12:00:00', 50, 1, 1),
+  ('Morning Standup', 'Plan the schedule for the week and assign tickets.', 3, 1, '10:00:00', '11:00:00', 60, 3, @curriculumId),
+  ('GitHub Collaboration Demo', '', 3, 1, '11:10:00', '12:00:00', 50, 1, @curriculumId),
   -- Week 3: Day 2
-  ('Self-assessment', '', 3, 2, NULL, NULL, NULL, 2, 1),
-  ('Collaborative Work Period', 'Work on a group ticket.', 3, 2, '11:00:00', '24:00:00', 780, 1, 1),
+  ('Self-assessment', '', 3, 2, NULL, NULL, NULL, 2, @curriculumId),
+  ('Collaborative Work Period', 'Work on a group ticket.', 3, 2, '11:00:00', '24:00:00', 780, 1, @curriculumId),
   -- Week 3: Day 3
-  ('Morning Standup', 'Check progress.', 3, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Collaborative Work Period', 'Work on a group ticket.', 3, 3, '12:10:00', '24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check progress.', 3, 3, '11:00:00', '12:00:00', 60, 3, @curriculumId),
+  ('Collaborative Work Period', 'Work on a group ticket.', 3, 3, '12:10:00', '24:00:00', 710, 1, @curriculumId),
   -- Week 3: Day 4
-  ('Game Time', '', 3, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Collaborative Work Period', 'Work on a group ticket.', 3, 4, '10:40:00', '24:00:00', 800, 1, 1),
+  ('Game Time', '', 3, 4, '10:00:00', '10:30:00', 30, 1, @curriculumId),
+  ('Collaborative Work Period', 'Work on a group ticket.', 3, 4, '10:40:00', '24:00:00', 800, 1, @curriculumId),
   -- Week 3: Day 5
-  ('Self-reflection', '', 3, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('One-on-one Mentorship Session', '', 3, 5, '11:10:00', '13:10:00', 120, 4, 1),
+  ('Self-reflection', '', 3, 5, '10:00:00', '11:00:00', 60, 4, @curriculumId),
+  ('One-on-one Mentorship Session', '', 3, 5, '11:10:00', '13:10:00', 120, 4, @curriculumId),
   -- Week 4: Day 1
-  ('Morning Standup', '', 4, 1, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 4, 1, '11:10:00', '12:00:00', 50, 1, 1), 
+  ('Morning Standup', '', 4, 1, '10:00:00', '11:00:00', 60, 3, @curriculumId),
+  ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 4, 1, '11:10:00', '12:00:00', 50, 1, @curriculumId), 
   -- Week 4: Day 2
-  ('Self-assessment', '', 4, 2, NULL, NULL, NULL, 2, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 4, 2, '10:00:00', '24:00:00', 840, 1, 1),
+  ('Self-assessment', '', 4, 2, NULL, NULL, NULL, 2, @curriculumId),
+  ('Independent Work Time', 'Work on the assigned ticket.', 4, 2, '10:00:00', '24:00:00', 840, 1, @curriculumId),
   -- Week 4: Day 3
-  ('Morning Standup', 'Check progress.', 4, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 4, 3, '12:10:00', '24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check progress.', 4, 3, '11:00:00', '12:00:00', 60, 3, @curriculumId),
+  ('Independent Work Time', 'Work on the assigned ticket.', 4, 3, '12:10:00', '24:00:00', 710, 1, @curriculumId),
   -- Week 4: Day 4
-  ('Game Time', '', 4, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 4, 4, '10:00:00', '24:00:00', 840, 1, 1),
+  ('Game Time', '', 4, 4, '10:00:00', '10:30:00', 30, 1, @curriculumId),
+  ('Independent Work Time', 'Work on the assigned ticket.', 4, 4, '10:00:00', '24:00:00', 840, 1, @curriculumId),
   -- Week 4: Day 5
-  ('Self-reflection', '', 4, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('One-on-one Mentorship Session', '', 4, 5, '11:10:00', '13:10:00', 120, 4, 1),
+  ('Self-reflection', '', 4, 5, '10:00:00', '11:00:00', 60, 4, @curriculumId),
+  ('One-on-one Mentorship Session', '', 4, 5, '11:10:00', '13:10:00', 120, 4, @curriculumId),
   -- Week 5: Day 1
-  ('Morning Standup', '', 5, 1, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 5, 1, '11:10:00', '12:00:00', 50, 1, 1), 
+  ('Morning Standup', '', 5, 1, '10:00:00', '11:00:00', 60, 3, @curriculumId),
+  ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 5, 1, '11:10:00', '12:00:00', 50, 1, @curriculumId), 
   -- Week 5: Day 2
-  ('Self-assessment', '', 5, 2, NULL, NULL, NULL, 2, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 5, 2, '10:00:00', '24:00:00', 840, 1, 1),
+  ('Self-assessment', '', 5, 2, NULL, NULL, NULL, 2, @curriculumId),
+  ('Independent Work Time', 'Work on the assigned ticket.', 5, 2, '10:00:00', '24:00:00', 840, 1, @curriculumId),
   -- Week 5: Day 3 
-  ('Morning Standup', 'Check progress.', 5, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 5, 3, '12:10:00', '24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check progress.', 5, 3, '11:00:00', '12:00:00', 60, 3, @curriculumId),
+  ('Independent Work Time', 'Work on the assigned ticket.', 5, 3, '12:10:00', '24:00:00', 710, 1, @curriculumId),
   -- Week 5: Day 4  
-  ('Game Time', '', 5, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 5, 4, '10:00:00', '24:00:00', 840, 1, 1),
+  ('Game Time', '', 5, 4, '10:00:00', '10:30:00', 30, 1, @curriculumId),
+  ('Independent Work Time', 'Work on the assigned ticket.', 5, 4, '10:00:00', '24:00:00', 840, 1, @curriculumId),
   -- Week 5: Day 5  
-  ('Self-reflection', '', 5, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('One-on-one Mentorship Session', '', 5, 5, '11:10:00', '13:10:00', 120, 4, 1),
+  ('Self-reflection', '', 5, 5, '10:00:00', '11:00:00', 60, 4, @curriculumId),
+  ('One-on-one Mentorship Session', '', 5, 5, '11:10:00', '13:10:00', 120, 4, @curriculumId),
   -- Week 6: Day 1  
-  ('Morning Standup', '', 6, 1, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 6, 1, '11:10:00', '12:00:00', 50, 1, 1), 
+  ('Morning Standup', '', 6, 1, '10:00:00', '11:00:00', 60, 3, @curriculumId),
+  ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 6, 1, '11:10:00', '12:00:00', 50, 1, @curriculumId), 
   -- Week 6: Day 2 
-  ('Self-assessment', '', 6, 2, NULL, NULL, NULL, 2, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 6, 2, '10:00:00', '24:00:00', 840, 1, 1),
+  ('Self-assessment', '', 6, 2, NULL, NULL, NULL, 2, @curriculumId),
+  ('Independent Work Time', 'Work on the assigned ticket.', 6, 2, '10:00:00', '24:00:00', 840, 1, @curriculumId),
   -- Week 6: Day 3 
-  ('Morning Standup', 'Check progress.', 6, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 6, 3, '12:10:00', '24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check progress.', 6, 3, '11:00:00', '12:00:00', 60, 3, @curriculumId),
+  ('Independent Work Time', 'Work on the assigned ticket.', 6, 3, '12:10:00', '24:00:00', 710, 1, @curriculumId),
   -- Week 6: Day 4  
-  ('Game Time', '', 6, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 6, 2, '11:00:00', '24:00:00', 780, 1, 1),
+  ('Game Time', '', 6, 4, '10:00:00', '10:30:00', 30, 1, @curriculumId),
+  ('Independent Work Time', 'Work on the assigned ticket.', 6, 2, '11:00:00', '24:00:00', 780, 1, @curriculumId),
   -- Week 6: Day 5  
-  ('Self-reflection', '', 6, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('One-on-one Mentorship Session', '', 6, 5, '11:10:00', '13:10:00', 120, 4, 1),
+  ('Self-reflection', '', 6, 5, '10:00:00', '11:00:00', 60, 4, @curriculumId),
+  ('One-on-one Mentorship Session', '', 6, 5, '11:10:00', '13:10:00', 120, 4, @curriculumId),
   -- Week 7: Day 1  
-  ('Morning Standup', '', 7, 1, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 7, 1, '11:10:00', '12:00:00', 50, 1, 1), 
+  ('Morning Standup', '', 7, 1, '10:00:00', '11:00:00', 60, 3, @curriculumId),
+  ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 7, 1, '11:10:00', '12:00:00', 50, 1, @curriculumId), 
   -- Week 7: Day 2 
-  ('Self-assessment', '', 7, 2, NULL, NULL, NULL, 2, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 7, 2, '11:00:00', '24:00:00', 780, 1, 1),
+  ('Self-assessment', '', 7, 2, NULL, NULL, NULL, 2, @curriculumId),
+  ('Independent Work Time', 'Work on the assigned ticket.', 7, 2, '11:00:00', '24:00:00', 780, 1, @curriculumId),
   -- Week 7: Day 3
-  ('Morning Standup', 'Check progress.', 7, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 7, 3, '12:10:00', '24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check progress.', 7, 3, '11:00:00', '12:00:00', 60, 3, @curriculumId),
+  ('Independent Work Time', 'Work on the assigned ticket.', 7, 3, '12:10:00', '24:00:00', 710, 1, @curriculumId),
   -- Week 7: Day 4 
-  ('Game Time', '', 7, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 7, 4, '11:00:00', '24:00:00', 780, 1, 1),
+  ('Game Time', '', 7, 4, '10:00:00', '10:30:00', 30, 1, @curriculumId),
+  ('Independent Work Time', 'Work on the assigned ticket.', 7, 4, '11:00:00', '24:00:00', 780, 1, @curriculumId),
   -- Week 7: Day 5  
-  ('Self-reflection', '', 7, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('One-on-one Mentorship Session', '', 7, 5, '11:10:00', '13:10:00', 120, 4, 1),
+  ('Self-reflection', '', 7, 5, '10:00:00', '11:00:00', 60, 4, @curriculumId),
+  ('One-on-one Mentorship Session', '', 7, 5, '11:10:00', '13:10:00', 120, 4, @curriculumId),
   -- Week 8: Day 1  
-  ('Morning Standup', '', 8, 1, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 8, 1, '11:10:00', '12:00:00', 50, 1, 1), 
+  ('Morning Standup', '', 8, 1, '10:00:00', '11:00:00', 60, 3, @curriculumId),
+  ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 8, 1, '11:10:00', '12:00:00', 50, 1, @curriculumId), 
   -- Week 8: Day 2 
-  ('Self-assessment', '', 8, 2, NULL, NULL, NULL, 2, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 8, 2, '11:00:00', '24:00:00', 780, 1, 1),
+  ('Self-assessment', '', 8, 2, NULL, NULL, NULL, 2, @curriculumId),
+  ('Independent Work Time', 'Work on the assigned ticket.', 8, 2, '11:00:00', '24:00:00', 780, 1, @curriculumId),
   -- Week 8: Day 3  
-  ('Morning Standup', 'Check progress.', 8, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 8, 3, '12:10:00', '24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check progress.', 8, 3, '11:00:00', '12:00:00', 60, 3, @curriculumId),
+  ('Independent Work Time', 'Work on the assigned ticket.', 8, 3, '12:10:00', '24:00:00', 710, 1, @curriculumId),
 -- Week 8: Day 4    
-  ('Game Time', '', 8, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 8, 4, '11:00:00', '24:00:00', 780, 1, 1),
+  ('Game Time', '', 8, 4, '10:00:00', '10:30:00', 30, 1, @curriculumId),
+  ('Independent Work Time', 'Work on the assigned ticket.', 8, 4, '11:00:00', '24:00:00', 780, 1, @curriculumId),
 -- Week 8: Day 5   
-  ('Self-reflection', '', 8, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('One-on-one Mentorship Session', '', 8, 5, '11:10:00', '13:10:00', 120, 4, 1);
+  ('Self-reflection', '', 8, 5, '10:00:00', '11:00:00', 60, 4, @curriculumId),
+  ('One-on-one Mentorship Session', '', 8, 5, '11:10:00', '13:10:00', 120, 4, @curriculumId);

--- a/db/migration/V020__insert_default_activities.sql
+++ b/db/migration/V020__insert_default_activities.sql
@@ -7,7 +7,7 @@ INSERT INTO activities (title, description_text, curriculum_week, curriculum_day
   ('Self-introduction', 'Get to know each other.', 1, 1, '11:10:00', '12:00:00', 50, 1, 1),
   -- Week 1: Day 2
   ('Self-assessment', '', 1, 2, NULL, NULL, NULL, 2, 1),
-  ('PMP Inroduction', 'Overview of the project and technological environment.', 1, 2, '11:00:00', '12:00:00', 60, 1, 1),
+  ('PMP Introduction', 'Overview of the project and technological environment.', 1, 2, '11:00:00', '12:00:00', 60, 1, 1),
   ('Set up Local Copy of Repository', 'Clone the repository and follow the instructions to set it up on your development machine.', 1, 2, NULL, NULL, NULL, 2, 1),  
   -- Week 1: Day 3
   ('Morning Standup', 'Check progress.', 1, 3, '11:00:00', '12:00:00', 60, 3, 1),
@@ -17,7 +17,7 @@ INSERT INTO activities (title, description_text, curriculum_week, curriculum_day
   ('Product Specification', 'Go through the Product Specification.', 1, 4, '11:00:00', '13:00:00', 120, 1, 1),
   -- Week 1: Day 5
   ('Self-reflection', '', 1, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('Data flow demostration', 'Go through the existing codes on the app.', 1, 5, '11:05:00', '13:00:00', 115, 1, 1),
+  ('Data Flow Demonstration', 'Review the existing code structure from the perspective of how data flows through the app.', 1, 5, '11:05:00', '13:00:00', 115, 1, 1),
   -- Week 2: Day 1
   ('Morning Standup', '', 2, 1, '10:00:00', '11:00:00', 60, 3, 1), 
   ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 1, NULL, NULL, NULL, 1, 1),
@@ -25,26 +25,26 @@ INSERT INTO activities (title, description_text, curriculum_week, curriculum_day
   ('Self-assessment', '', 2, 2, NULL, NULL, NULL, 2, 1),
   ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 2, NULL, NULL, NULL, 1, 1),
   -- Week 2: Day 3
-  ('Morning Standup', 'Check the progress.', 2, 3, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Morning Standup', 'Check progress.', 2, 3, '10:00:00', '11:00:00', 60, 3, 1),
   ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 3, NULL, NULL, NULL, 1, 1),
   -- Week 2: Day 4
   ('Game Time', '', 2, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 4, NULL, NULL, NULL, 1, 1),
   -- Week 2: Day 5
   ('Self-reflection', '', 2, 5, '10:00:00', '11:00:00', 60, 4, 1),
-  ('Prototyping Demo', 'Demostrate the prototype from each group.', 2, 5, '11:10:00', '13:30:00', 140, 2, 1),
+  ('Prototyping Demo', 'Demonstrate prototype of each team.', 2, 5, '11:10:00', '13:30:00', 140, 2, 1),
   -- Week 3: Day 1
   ('Morning Standup', 'Plan the schedule for the week and assign tickets.', 3, 1, '10:00:00', '11:00:00', 60, 3, 1),
-  ('Github Collaboration Demo', '', 3, 1, '11:10:00', '12:00:00', 50, 1, 1),
+  ('GitHub Collaboration Demo', '', 3, 1, '11:10:00', '12:00:00', 50, 1, 1),
   -- Week 3: Day 2
   ('Self-assessment', '', 3, 2, NULL, NULL, NULL, 2, 1),
-  ('Collaborative Work Period', 'Work on a group ticket.', 3, 2, '11:00:00','24:00:00', 780, 1, 1),
+  ('Collaborative Work Period', 'Work on a group ticket.', 3, 2, '11:00:00', '24:00:00', 780, 1, 1),
   -- Week 3: Day 3
-  ('Morning Standup', 'Check the progress.', 3, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Collaborative Work Period', 'Work on a group ticket.', 3, 3, '12:10:00','24:00:00', 780, 1, 1),
+  ('Morning Standup', 'Check progress.', 3, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Collaborative Work Period', 'Work on a group ticket.', 3, 3, '12:10:00', '24:00:00', 710, 1, 1),
   -- Week 3: Day 4
   ('Game Time', '', 3, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Collaborative Work Period', 'Work on a group ticket.', 3, 4, '10:40:00','24:00:00', 800, 1, 1),
+  ('Collaborative Work Period', 'Work on a group ticket.', 3, 4, '10:40:00', '24:00:00', 800, 1, 1),
   -- Week 3: Day 5
   ('Self-reflection', '', 3, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('One-on-one Mentorship Session', '', 3, 5, '11:10:00', '13:10:00', 120, 4, 1),
@@ -53,28 +53,28 @@ INSERT INTO activities (title, description_text, curriculum_week, curriculum_day
   ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 4, 1, '11:10:00', '12:00:00', 50, 1, 1), 
   -- Week 4: Day 2
   ('Self-assessment', '', 4, 2, NULL, NULL, NULL, 2, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 4, 2, '10:00:00','24:00:00', 840, 1, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 4, 2, '10:00:00', '24:00:00', 840, 1, 1),
   -- Week 4: Day 3
-  ('Morning Standup', 'Check the progress.', 4, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 4, 3, '12:10:00','24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check progress.', 4, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 4, 3, '12:10:00', '24:00:00', 710, 1, 1),
   -- Week 4: Day 4
   ('Game Time', '', 4, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 4, 4, '10:00:00','24:00:00', 840, 1, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 4, 4, '10:00:00', '24:00:00', 840, 1, 1),
   -- Week 4: Day 5
-  ('Self reflection', '', 4, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('Self-reflection', '', 4, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('One-on-one Mentorship Session', '', 4, 5, '11:10:00', '13:10:00', 120, 4, 1),
   -- Week 5: Day 1
   ('Morning Standup', '', 5, 1, '10:00:00', '11:00:00', 60, 3, 1),
   ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 5, 1, '11:10:00', '12:00:00', 50, 1, 1), 
   -- Week 5: Day 2
   ('Self-assessment', '', 5, 2, NULL, NULL, NULL, 2, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 5, 2, '10:00:00','24:00:00', 840, 1, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 5, 2, '10:00:00', '24:00:00', 840, 1, 1),
   -- Week 5: Day 3 
-  ('Morning Standup', 'Check the progress.', 5, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 5, 3, '12:10:00','24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check progress.', 5, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 5, 3, '12:10:00', '24:00:00', 710, 1, 1),
   -- Week 5: Day 4  
   ('Game Time', '', 5, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 5, 4, '10:00:00','24:00:00', 840, 1, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 5, 4, '10:00:00', '24:00:00', 840, 1, 1),
   -- Week 5: Day 5  
   ('Self-reflection', '', 5, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('One-on-one Mentorship Session', '', 5, 5, '11:10:00', '13:10:00', 120, 4, 1),
@@ -83,13 +83,13 @@ INSERT INTO activities (title, description_text, curriculum_week, curriculum_day
   ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 6, 1, '11:10:00', '12:00:00', 50, 1, 1), 
   -- Week 6: Day 2 
   ('Self-assessment', '', 6, 2, NULL, NULL, NULL, 2, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 6, 2, '10:00:00','24:00:00', 840, 1, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 6, 2, '10:00:00', '24:00:00', 840, 1, 1),
   -- Week 6: Day 3 
-  ('Morning Standup', 'Check the progress.', 6, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 6, 3, '12:10:00','24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check progress.', 6, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 6, 3, '12:10:00', '24:00:00', 710, 1, 1),
   -- Week 6: Day 4  
   ('Game Time', '', 6, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 6, 2, '11:00:00','24:00:00', 780, 1, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 6, 2, '11:00:00', '24:00:00', 780, 1, 1),
   -- Week 6: Day 5  
   ('Self-reflection', '', 6, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('One-on-one Mentorship Session', '', 6, 5, '11:10:00', '13:10:00', 120, 4, 1),
@@ -98,13 +98,13 @@ INSERT INTO activities (title, description_text, curriculum_week, curriculum_day
   ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 7, 1, '11:10:00', '12:00:00', 50, 1, 1), 
   -- Week 7: Day 2 
   ('Self-assessment', '', 7, 2, NULL, NULL, NULL, 2, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 7, 2, '11:00:00','24:00:00', 780, 1, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 7, 2, '11:00:00', '24:00:00', 780, 1, 1),
   -- Week 7: Day 3
-  ('Morning Standup', 'Check the progress..', 7, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 7, 3, '12:10:00','24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check progress.', 7, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 7, 3, '12:10:00', '24:00:00', 710, 1, 1),
   -- Week 7: Day 4 
   ('Game Time', '', 7, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 7, 4, '11:00:00','24:00:00', 780, 1, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 7, 4, '11:00:00', '24:00:00', 780, 1, 1),
   -- Week 7: Day 5  
   ('Self-reflection', '', 7, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('One-on-one Mentorship Session', '', 7, 5, '11:10:00', '13:10:00', 120, 4, 1),
@@ -113,13 +113,13 @@ INSERT INTO activities (title, description_text, curriculum_week, curriculum_day
   ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 8, 1, '11:10:00', '12:00:00', 50, 1, 1), 
   -- Week 8: Day 2 
   ('Self-assessment', '', 8, 2, NULL, NULL, NULL, 2, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 8, 2, '11:00:00','24:00:00', 780, 1, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 8, 2, '11:00:00', '24:00:00', 780, 1, 1),
   -- Week 8: Day 3  
-  ('Morning Standup', 'Check the progress.', 8, 3, '11:00:00', '12:00:00', 60, 3, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 8, 3, '12:10:00','24:00:00', 710, 1, 1),
+  ('Morning Standup', 'Check progress.', 8, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 8, 3, '12:10:00', '24:00:00', 710, 1, 1),
 -- Week 8: Day 4    
   ('Game Time', '', 8, 4, '10:00:00', '10:30:00', 30, 1, 1),
-  ('Independent Work Time', 'Work on the assigned ticket.', 8, 4, '11:00:00','24:00:00', 780, 1, 1),
+  ('Independent Work Time', 'Work on the assigned ticket.', 8, 4, '11:00:00', '24:00:00', 780, 1, 1),
 -- Week 8: Day 5   
   ('Self-reflection', '', 8, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('One-on-one Mentorship Session', '', 8, 5, '11:10:00', '13:10:00', 120, 4, 1);

--- a/db/migration/V020__insert_default_activities.sql
+++ b/db/migration/V020__insert_default_activities.sql
@@ -16,7 +16,7 @@ INSERT INTO activities (title, description_text, curriculum_week, curriculum_day
   ('Game time', '', 1, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Product Specification', 'Go through the Product Specification', 1, 4, '11:00:00', '13:00:00', 120, 1, 1),
   --Week 1: Day 5
-  ('Self relection', '', 1, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('Self-reflection', '', 1, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('Data flow demostration', 'Go through the existing codes on the app', 1, 5, '11:05:00', '13:00:00', 115, 1, 1),
   --Week 2: Day 1
   ('Morning standu', '', 2, 1, '10:00:00', '11:00:00', 60, 3, 1), 
@@ -31,7 +31,7 @@ INSERT INTO activities (title, description_text, curriculum_week, curriculum_day
   ('Game time', '', 2, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design', 2, 4, NULL, NULL, NULL, 1, 1),
   --Week 2: Day 5
-  ('Self relection', '', 2, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('Self-reflection', '', 2, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('Prototyping Demo', 'Demostrate the prototype from each group', 2, 5, '11:10:00', '13:30:00', 140, 2, 1),
   --Week 3: Day 1
   ('Morning standup', '', 3, 1, '10:00:00', '11:00:00', 60, 3, 1),
@@ -46,7 +46,7 @@ INSERT INTO activities (title, description_text, curriculum_week, curriculum_day
   ('Game time', '', 3, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Group working', 'Working on the ticket', 3, 4, '10:40:00','24:00:00', 800, 1, 1),
   --Week 3: Day 5
-  ('Self relection', '', 3, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('Self-reflection', '', 3, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('1:1 mentorship', '', 3, 5, '11:10:00', '13:10:00', 120, 4, 1),
   --Week 4: Day 1
   ('Morning standup', '', 4, 1, '10:00:00', '11:00:00', 60, 3, 1),
@@ -76,7 +76,7 @@ INSERT INTO activities (title, description_text, curriculum_week, curriculum_day
   ('Game time', '', 5, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Working on the ticket', 'Working on the assigned ticket', 5, 4, '10:00:00','24:00:00', 840, 1, 1),
   --Week 5: Day 5  
-  ('Self relection', '', 5, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('Self-reflection', '', 5, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('1:1 mentorship', '', 5, 5, '11:10:00', '13:10:00', 120, 4, 1),
   --Week 6: Day 1  
   ('Morning standup', '', 6, 1, '10:00:00', '11:00:00', 60, 3, 1),
@@ -91,7 +91,7 @@ INSERT INTO activities (title, description_text, curriculum_week, curriculum_day
   ('Game time', '', 6, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Working on the ticket', 'Working on the assigned ticket', 6, 2, '11:00:00','24:00:00', 780, 1, 1),
   --Week 6: Day 5  
-  ('Self relection', '', 6, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('Self-reflection', '', 6, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('1:1 mentorship', '', 6, 5, '11:10:00', '13:10:00', 120, 4, 1),
   --Week 7: Day 1  
   ('Morning standup', '', 7, 1, '10:00:00', '11:00:00', 60, 3, 1),
@@ -106,7 +106,7 @@ INSERT INTO activities (title, description_text, curriculum_week, curriculum_day
   ('Game time', '', 7, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Working on the ticket', 'Working on the assigned ticket', 7, 4, '11:00:00','24:00:00', 780, 1, 1),
   --Week 7: Day 5  
-  ('Self relection', '', 7, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('Self-reflection', '', 7, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('1:1 mentorship', '', 7, 5, '11:10:00', '13:10:00', 120, 4, 1),
   --Week 8: Day 1  
   ('Morning standup', '', 8, 1, '10:00:00', '11:00:00', 60, 3, 1),
@@ -121,8 +121,5 @@ INSERT INTO activities (title, description_text, curriculum_week, curriculum_day
   ('Game time', '', 8, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Working on the ticket', 'Working on the assigned ticket', 8, 4, '11:00:00','24:00:00', 780, 1, 1),
   --Week 8: Day 5   
-  ('Self relection', '', 8, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('Self-reflection', '', 8, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('1:1 mentorship', '', 8, 5, '11:10:00', '13:10:00', 120, 4, 1);
-
-
-

--- a/db/migration/V020__insert_default_activities.sql
+++ b/db/migration/V020__insert_default_activities.sql
@@ -2,125 +2,124 @@ INSERT INTO curriculums (principal_id, title) VALUES
   (1, 'Professional Mentorship Program');
 
 INSERT INTO activities (title, description_text, curriculum_week, curriculum_day, start_time, end_time, duration, activity_type_id, curriculum_id) VALUES
-  --Week 1: Day 1
+  -- Week 1: Day 1
   ('Morning Standup', '', 1, 1, '10:00:00', '11:00:00', 60, 3, 1),
   ('Self-introduction', 'Get to know each other.', 1, 1, '11:10:00', '12:00:00', 50, 1, 1),
-  --Week 1: Day 2
+  -- Week 1: Day 2
   ('Self-assessment', '', 1, 2, NULL, NULL, NULL, 2, 1),
   ('PMP Inroduction', 'Overview of the project and technological environment.', 1, 2, '11:00:00', '12:00:00', 60, 1, 1),
   ('Set up Local Copy of Repository', 'Clone the repository and follow the instructions to set it up on your development machine.', 1, 2, NULL, NULL, NULL, 2, 1),  
-  --Week 1: Day 3
+  -- Week 1: Day 3
   ('Morning Standup', 'Check progress.', 1, 3, '11:00:00', '12:00:00', 60, 3, 1),
   ('Product Brief', 'Go through the Product Brief.', 1, 3, '12:10:00', '13:00:00', 50, 1, 1),
-  --Week 1: Day 4
+  -- Week 1: Day 4
   ('Game Time', '', 1, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Product Specification', 'Go through the Product Specification.', 1, 4, '11:00:00', '13:00:00', 120, 1, 1),
-  --Week 1: Day 5
+  -- Week 1: Day 5
   ('Self-reflection', '', 1, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('Data flow demostration', 'Go through the existing codes on the app.', 1, 5, '11:05:00', '13:00:00', 115, 1, 1),
-  --Week 2: Day 1
+  -- Week 2: Day 1
   ('Morning Standup', '', 2, 1, '10:00:00', '11:00:00', 60, 3, 1), 
   ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 1, NULL, NULL, NULL, 1, 1),
-  --Week 2: Day 2
+  -- Week 2: Day 2
   ('Self-assessment', '', 2, 2, NULL, NULL, NULL, 2, 1),
   ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 2, NULL, NULL, NULL, 1, 1),
-  --Week 2: Day 3
-  ('Morning Standup', 'Check the progress', 2, 3, '10:00:00', '11:00:00', 60, 3, 1),
+  -- Week 2: Day 3
+  ('Morning Standup', 'Check the progress.', 2, 3, '10:00:00', '11:00:00', 60, 3, 1),
   ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 3, NULL, NULL, NULL, 1, 1),
-  --Week 2: Day 4
+  -- Week 2: Day 4
   ('Game Time', '', 2, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design.', 2, 4, NULL, NULL, NULL, 1, 1),
-  --Week 2: Day 5
+  -- Week 2: Day 5
   ('Self-reflection', '', 2, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('Prototyping Demo', 'Demostrate the prototype from each group.', 2, 5, '11:10:00', '13:30:00', 140, 2, 1),
-  --Week 3: Day 1
+  -- Week 3: Day 1
   ('Morning Standup', 'Plan the schedule for the week and assign tickets.', 3, 1, '10:00:00', '11:00:00', 60, 3, 1),
   ('Github Collaboration Demo', '', 3, 1, '11:10:00', '12:00:00', 50, 1, 1),
-  --Week 3: Day 2
+  -- Week 3: Day 2
   ('Self-assessment', '', 3, 2, NULL, NULL, NULL, 2, 1),
   ('Collaborative Work Period', 'Work on a group ticket.', 3, 2, '11:00:00','24:00:00', 780, 1, 1),
-  --Week 3: Day 3
-  ('Morning Standup', 'Check the progress', 3, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  -- Week 3: Day 3
+  ('Morning Standup', 'Check the progress.', 3, 3, '11:00:00', '12:00:00', 60, 3, 1),
   ('Collaborative Work Period', 'Work on a group ticket.', 3, 3, '12:10:00','24:00:00', 780, 1, 1),
-  --Week 3: Day 4
+  -- Week 3: Day 4
   ('Game Time', '', 3, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Collaborative Work Period', 'Work on a group ticket.', 3, 4, '10:40:00','24:00:00', 800, 1, 1),
-  --Week 3: Day 5
+  -- Week 3: Day 5
   ('Self-reflection', '', 3, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('One-on-one Mentorship Session', '', 3, 5, '11:10:00', '13:10:00', 120, 4, 1),
-  --Week 4: Day 1
+  -- Week 4: Day 1
   ('Morning Standup', '', 4, 1, '10:00:00', '11:00:00', 60, 3, 1),
   ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 4, 1, '11:10:00', '12:00:00', 50, 1, 1), 
-  --Week 4: Day 2
+  -- Week 4: Day 2
   ('Self-assessment', '', 4, 2, NULL, NULL, NULL, 2, 1),
   ('Independent Work Time', 'Work on the assigned ticket.', 4, 2, '10:00:00','24:00:00', 840, 1, 1),
-  --Week 4: Day 3
-  ('Morning Standup', 'Check the progress', 4, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  -- Week 4: Day 3
+  ('Morning Standup', 'Check the progress.', 4, 3, '11:00:00', '12:00:00', 60, 3, 1),
   ('Independent Work Time', 'Work on the assigned ticket.', 4, 3, '12:10:00','24:00:00', 710, 1, 1),
-  --Week 4: Day 4
+  -- Week 4: Day 4
   ('Game Time', '', 4, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Independent Work Time', 'Work on the assigned ticket.', 4, 4, '10:00:00','24:00:00', 840, 1, 1),
-  --Week 4: Day 5
+  -- Week 4: Day 5
   ('Self reflection', '', 4, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('One-on-one Mentorship Session', '', 4, 5, '11:10:00', '13:10:00', 120, 4, 1),
-  --Week 5: Day 1
+  -- Week 5: Day 1
   ('Morning Standup', '', 5, 1, '10:00:00', '11:00:00', 60, 3, 1),
   ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 5, 1, '11:10:00', '12:00:00', 50, 1, 1), 
-  --Week 5: Day 2
+  -- Week 5: Day 2
   ('Self-assessment', '', 5, 2, NULL, NULL, NULL, 2, 1),
   ('Independent Work Time', 'Work on the assigned ticket.', 5, 2, '10:00:00','24:00:00', 840, 1, 1),
-  --Week 5: Day 3 
-  ('Morning Standup', 'Check the progress', 5, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  -- Week 5: Day 3 
+  ('Morning Standup', 'Check the progress.', 5, 3, '11:00:00', '12:00:00', 60, 3, 1),
   ('Independent Work Time', 'Work on the assigned ticket.', 5, 3, '12:10:00','24:00:00', 710, 1, 1),
-  --Week 5: Day 4  
+  -- Week 5: Day 4  
   ('Game Time', '', 5, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Independent Work Time', 'Work on the assigned ticket.', 5, 4, '10:00:00','24:00:00', 840, 1, 1),
-  --Week 5: Day 5  
+  -- Week 5: Day 5  
   ('Self-reflection', '', 5, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('One-on-one Mentorship Session', '', 5, 5, '11:10:00', '13:10:00', 120, 4, 1),
-  --Week 6: Day 1  
+  -- Week 6: Day 1  
   ('Morning Standup', '', 6, 1, '10:00:00', '11:00:00', 60, 3, 1),
   ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 6, 1, '11:10:00', '12:00:00', 50, 1, 1), 
-  --Week 6: Day 2 
+  -- Week 6: Day 2 
   ('Self-assessment', '', 6, 2, NULL, NULL, NULL, 2, 1),
   ('Independent Work Time', 'Work on the assigned ticket.', 6, 2, '10:00:00','24:00:00', 840, 1, 1),
-  --Week 6: Day 3 
-  ('Morning Standup', 'Check the progress', 6, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  -- Week 6: Day 3 
+  ('Morning Standup', 'Check the progress.', 6, 3, '11:00:00', '12:00:00', 60, 3, 1),
   ('Independent Work Time', 'Work on the assigned ticket.', 6, 3, '12:10:00','24:00:00', 710, 1, 1),
-  --Week 6: Day 4  
+  -- Week 6: Day 4  
   ('Game Time', '', 6, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Independent Work Time', 'Work on the assigned ticket.', 6, 2, '11:00:00','24:00:00', 780, 1, 1),
-  --Week 6: Day 5  
+  -- Week 6: Day 5  
   ('Self-reflection', '', 6, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('One-on-one Mentorship Session', '', 6, 5, '11:10:00', '13:10:00', 120, 4, 1),
-  --Week 7: Day 1  
+  -- Week 7: Day 1  
   ('Morning Standup', '', 7, 1, '10:00:00', '11:00:00', 60, 3, 1),
   ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 7, 1, '11:10:00', '12:00:00', 50, 1, 1), 
-  --Week 7: Day 2 
+  -- Week 7: Day 2 
   ('Self-assessment', '', 7, 2, NULL, NULL, NULL, 2, 1),
   ('Independent Work Time', 'Work on the assigned ticket.', 7, 2, '11:00:00','24:00:00', 780, 1, 1),
-  --Week 7: Day 3
-  ('Morning Standup', 'Check the progress.', 7, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  -- Week 7: Day 3
+  ('Morning Standup', 'Check the progress..', 7, 3, '11:00:00', '12:00:00', 60, 3, 1),
   ('Independent Work Time', 'Work on the assigned ticket.', 7, 3, '12:10:00','24:00:00', 710, 1, 1),
-  --Week 7: Day 4 
+  -- Week 7: Day 4 
   ('Game Time', '', 7, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Independent Work Time', 'Work on the assigned ticket.', 7, 4, '11:00:00','24:00:00', 780, 1, 1),
-  --Week 7: Day 5  
+  -- Week 7: Day 5  
   ('Self-reflection', '', 7, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('One-on-one Mentorship Session', '', 7, 5, '11:10:00', '13:10:00', 120, 4, 1),
-  --Week 8: Day 1  
+  -- Week 8: Day 1  
   ('Morning Standup', '', 8, 1, '10:00:00', '11:00:00', 60, 3, 1),
   ('Sprint Planning', 'Plan the schedule for the week and assign tickets.', 8, 1, '11:10:00', '12:00:00', 50, 1, 1), 
-  --Week 8: Day 2 
+  -- Week 8: Day 2 
   ('Self-assessment', '', 8, 2, NULL, NULL, NULL, 2, 1),
   ('Independent Work Time', 'Work on the assigned ticket.', 8, 2, '11:00:00','24:00:00', 780, 1, 1),
-  --Week 8: Day 3  
-  ('Morning Standup', 'Check the progress', 8, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  -- Week 8: Day 3  
+  ('Morning Standup', 'Check the progress.', 8, 3, '11:00:00', '12:00:00', 60, 3, 1),
   ('Independent Work Time', 'Work on the assigned ticket.', 8, 3, '12:10:00','24:00:00', 710, 1, 1),
-  --Week 8: Day 4    
+-- Week 8: Day 4    
   ('Game Time', '', 8, 4, '10:00:00', '10:30:00', 30, 1, 1),
   ('Independent Work Time', 'Work on the assigned ticket.', 8, 4, '11:00:00','24:00:00', 780, 1, 1),
-  --Week 8: Day 5   
+-- Week 8: Day 5   
   ('Self-reflection', '', 8, 5, '10:00:00', '11:00:00', 60, 4, 1),
   ('One-on-one Mentorship Session', '', 8, 5, '11:10:00', '13:10:00', 120, 4, 1);
-

--- a/db/migration/V020__insert_default_activities.sql
+++ b/db/migration/V020__insert_default_activities.sql
@@ -1,5 +1,128 @@
 INSERT INTO curriculums (principal_id, title) VALUES
   (1, 'Professional Mentorship Program');
+
 INSERT INTO activities (title, description_text, curriculum_week, curriculum_day, start_time, end_time, duration, activity_type_id, curriculum_id) VALUES
-  ('Set up local copy of repository', 'Clone the repository and follow the instructions to set it up on your development machine.', 1, 1, NULL, NULL, NULL, 2, 1),  
-  ('Morning standup', '', 1, 1, '10:00:00', '11:00:00', 60, 3, 1);
+  /* week1 -1 */
+  ('Morning standup', '', 1, 1, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Self Introduction', 'Getting to know each other', 1, 1, '11:10:00', '12:00:00', 50, 1, 1),
+  /* week1 -2*/
+  ('Self assignment', '', 1, 2, NULL, NULL, NULL, 2, 1),
+  ('PMP inroduction', 'An overview of the project and technological environment', 1, 2, '11:00:00', '12:00:00', 60, 1, 1),
+  ('Set up local copy of repository', 'Clone the repository and follow the instructions to set it up on your development machine.', 1, 2, NULL, NULL, NULL, 2, 1),  
+  /* week1 -3 */
+  ('Morning standup', 'Check the progress', 1, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Product Brief', 'Go through the Product Brief', 1, 3, '12:10:00', '13:00:00', 50, 1, 1),
+  /* week1 -4*/
+  ('Game time', '', 1, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Product Specification', 'Go through the Product Specification', 1, 4, '11:00:00', '13:00:00', 120, 1, 1),
+  /* week1 -5 */
+  ('Self relection', '', 1, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('Data flow demostration', 'Go through the existing codes on the app', 1, 5, '11:05:00', '13:00:00', 115, 1, 1),
+  /* week2 -1 */
+  ('Morning standup', '', 2, 1, '10:00:00', '11:00:00', 60, 3, 1), 
+  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design', 2, 1, NULL, NULL, NULL, 1, 1),
+  /* week2 -2 */
+  ('Self assignment', '', 2, 2, NULL, NULL, NULL, 2, 1),
+  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design', 2, 2, NULL, NULL, NULL, 1, 1),
+  /* week2 -3 */
+  ('Morning standup', 'Check the progress', 2, 3, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design', 2, 3, NULL, NULL, NULL, 1, 1),
+  /* week2 -4 */
+  ('Game time', '', 2, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Prototyping', 'Create messy code at the early stages of building a product to demonstrate its intended functionalities and design', 2, 4, NULL, NULL, NULL, 1, 1),
+  /* week2 -5 */
+  ('Self relection', '', 2, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('Prototyping Demo', 'Demostrate the prototype from each group', 2, 5, '11:10:00', '13:30:00', 140, 2, 1),
+  /* week3 -1 */
+  ('Morning standup', '', 3, 1, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Github collaboration demo', '', 3, 1, '11:10:00', '12:00:00', 50, 1, 1),
+  /* week3 -2 */
+  ('Self assignment', '', 3, 2, NULL, NULL, NULL, 2, 1),
+  ('Group working', 'Working on the ticket', 3, 2, '11:00:00','24:00:00', 780, 1, 1),
+  /* week3 -3 */
+  ('Morning standup', 'Check the progress', 3, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Group working', 'Working on the ticket', 3, 3, '12:10:00','24:00:00', 780, 1, 1),
+  /* week3 -4 */
+  ('Game time', '', 3, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Group working', 'Working on the ticket', 3, 4, '10:40:00','24:00:00', 800, 1, 1),
+  /* week3 -5 */
+  ('Self relection', '', 3, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('1:1 mentorship', '', 3, 5, '11:10:00', '13:10:00', 120, 4, 1),
+  /* week4 -1 */
+  ('Morning standup', '', 4, 1, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Sprint Planing', 'Planing the schedule for the week and assigning tickets', 4, 1, '11:10:00', '12:00:00', 50, 1, 1), 
+  /* week4 -2 */
+  ('Self assignment', '', 4, 2, NULL, NULL, NULL, 2, 1),
+  ('Working on the ticket', 'Working on the assigned ticket', 4, 2, '10:00:00','24:00:00', 840, 1, 1),
+  /* week4 -3 */
+  ('Morning standup', 'Check the progress', 4, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Working on the ticket', 'Working on the assigned ticket', 4, 3, '12:10:00','24:00:00', 710, 1, 1),
+  /* week4 -4 */
+  ('Game time', '', 4, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Working on the ticket', 'Working on the assigned ticket', 4, 4, '10:00:00','24:00:00', 840, 1, 1),
+  /* week4 -5 */
+  ('Self relection', '', 4, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('1:1 mentorship', '', 4, 5, '11:10:00', '13:10:00', 120, 4, 1),
+  /* week5 -1 */
+  ('Morning standup', '', 5, 1, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Sprint Planing', 'Planing the schedule for the week and assigning tickets', 5, 1, '11:10:00', '12:00:00', 50, 1, 1), 
+  /* week5 -2 */
+  ('Self assignment', '', 5, 2, NULL, NULL, NULL, 2, 1),
+  ('Working on the ticket', 'Working on the assigned ticket', 5, 2, '10:00:00','24:00:00', 840, 1, 1),
+  /* week5 -3 */ 
+  ('Morning standup', 'Check the progress', 5, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Working on the ticket', 'Working on the assigned ticket', 5, 3, '12:10:00','24:00:00', 710, 1, 1),
+  /* week5 -4 */ 
+  ('Game time', '', 5, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Working on the ticket', 'Working on the assigned ticket', 5, 4, '10:00:00','24:00:00', 840, 1, 1),
+  /* week5 -5 */ 
+  ('Self relection', '', 5, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('1:1 mentorship', '', 5, 5, '11:10:00', '13:10:00', 120, 4, 1),
+  /* week6 - 1*/ 
+  ('Morning standup', '', 6, 1, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Sprint Planing', 'Planing the schedule for the week and assigning tickets', 6, 1, '11:10:00', '12:00:00', 50, 1, 1), 
+  /* week6 - 2 */ 
+  ('Self assignment', '', 6, 2, NULL, NULL, NULL, 2, 1),
+  ('Working on the ticket', 'Working on the assigned ticket', 6, 2, '10:00:00','24:00:00', 840, 1, 1),
+  /* week6 - 3 */ 
+  ('Morning standup', 'Check the progress', 6, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Working on the ticket', 'Working on the assigned ticket', 6, 3, '12:10:00','24:00:00', 710, 1, 1),
+  /* week6 - 4 */ 
+  ('Game time', '', 6, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Working on the ticket', 'Working on the assigned ticket', 6, 2, '11:00:00','24:00:00', 780, 1, 1),
+  /* week6 - 5 */ 
+  ('Self relection', '', 6, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('1:1 mentorship', '', 6, 5, '11:10:00', '13:10:00', 120, 4, 1),
+  /* week7 - 1 */ 
+  ('Morning standup', '', 7, 1, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Sprint Planing', 'Planing the schedule for the week and assigning tickets', 7, 1, '11:10:00', '12:00:00', 50, 1, 1), 
+  /* week7 - 2 */ 
+  ('Self assignment', '', 7, 2, NULL, NULL, NULL, 2, 1),
+  ('Working on the ticket', 'Working on the assigned ticket', 7, 2, '11:00:00','24:00:00', 780, 1, 1),
+  /* week7 - 3 */ 
+  ('Morning standup', 'Check the progress', 7, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Working on the ticket', 'Working on the assigned ticket', 7, 3, '12:10:00','24:00:00', 710, 1, 1),
+  /* week7 - 4 */ 
+  ('Game time', '', 7, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Working on the ticket', 'Working on the assigned ticket', 7, 4, '11:00:00','24:00:00', 780, 1, 1),
+  /* week7 - 5 */ 
+  ('Self relection', '', 7, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('1:1 mentorship', '', 7, 5, '11:10:00', '13:10:00', 120, 4, 1),
+  /* week8 - 1 */ 
+  ('Morning standup', '', 8, 1, '10:00:00', '11:00:00', 60, 3, 1),
+  ('Sprint Planing', 'Planing the schedule for the week and assigning tickets', 8, 1, '11:10:00', '12:00:00', 50, 1, 1), 
+  /* week8 - 2 */ 
+  ('Self assignment', '', 8, 2, NULL, NULL, NULL, 2, 1),
+  ('Working on the ticket', 'Working on the assigned ticket', 8, 2, '11:00:00','24:00:00', 780, 1, 1),
+  /* week8 - 3 */ 
+  ('Morning standup', 'Check the progress', 8, 3, '11:00:00', '12:00:00', 60, 3, 1),
+  ('Working on the ticket', 'Working on the assigned ticket', 8, 3, '12:10:00','24:00:00', 710, 1, 1),
+  /* week8 - 4 */   
+  ('Game time', '', 8, 4, '10:00:00', '10:30:00', 30, 1, 1),
+  ('Working on the ticket', 'Working on the assigned ticket', 8, 4, '11:00:00','24:00:00', 780, 1, 1),
+  /* week8 - 5 */   
+  ('Self relection', '', 8, 5, '10:00:00', '11:00:00', 60, 4, 1),
+  ('1:1 mentorship', '', 8, 5, '11:10:00', '13:10:00', 120, 4, 1);
+
+
+

--- a/db/migration/V020__insert_default_activities.sql
+++ b/db/migration/V020__insert_default_activities.sql
@@ -1,14 +1,5 @@
-INSERT INTO questionnaires () VALUES
-  ();
-SET @questionnaire_id = LAST_INSERT_ID();
-INSERT INTO settings (property, content, category) VALUES
-  ('default_questionnaire_id', CAST(@questionnaire_id AS CHAR), 'webapp');
-INSERT INTO prompts (label, query_text, sort_order, questionnaire_id) VALUES
-  ('Outlook', 'How are you feeling about your current endeavours?', 1, @questionnaire_id);
-SET @prompt_id = LAST_INSERT_ID();
-INSERT INTO options (label, numeric_value, sort_order, prompt_id) VALUES
-  ('Very discouraged', -2, 1, @prompt_id),
-  ('A little discouraged', -1, 2, @prompt_id),
-  ('I don’t know', 0, 3, @prompt_id),
-  ('A little hopeful', 1, 4, @prompt_id),
-  ('Very hopeful', 2, 5, @prompt_id);
+INSERT INTO curriculums (principal_id, title) VALUES
+  (1, 'Professional Mentorship Program');
+INSERT INTO activities (title, description_text, curriculum_week, curriculum_day, start_time, end_time, duration, activity_type_id, curriculum_id) VALUES
+  ('Set up local copy of repository', 'Clone the repository and follow the instructions to set it up on your development machine.', 1, 1, NULL, NULL, NULL, 2, 1),  
+  ('Morning standup', '', 1, 1, '10:00:00', '11:00:00', 60, 3, 1);


### PR DESCRIPTION
Co-authored by: Phoebe Yu(@phoebehala)
Co-authored by: Veranika Karpava(@veranika-karpava)

## Proposed changes

This pull request resolves https://github.com/OpenTree-Education/rhizone-lms/issues/413.
The migration file includes default data of activities and curriculums records to populate curriculums and activities tables.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [ ] Are there screenshots for UI changes?
