### PR TITLE
#445 Add popup in Calendar to enable the show more via popup feature in month view

### DIFF
--- a/webapp/src/components/ProgramCalendar.tsx
+++ b/webapp/src/components/ProgramCalendar.tsx
@@ -60,6 +60,7 @@ const ProgramCalendar = ({ program }: ProgramCalendarProps) => {
         getNow={() => DateTime.local().toJSDate()}
         scrollToTime={DateTime.local().set({ hour: 8, minute: 0 }).toJSDate()}
         style={{ height: 500 }}
+        popup
       />
       <ProgramActivityDialog
         show={dialogShow}


### PR DESCRIPTION
## Proposed changes

This PR resolves the #445 by enabling the `react-big-calendar` to show a popup with all the activities of the selected date when the user clicks '+ more' in the calendar's month view. The activities in the popup are also clickable and show the activity dialog with activity information when clicked.

## Checklist

- [X] Are the issues being addressed linked to this PR?
- [X] Do all commit messages start with the issue number?
- [X] Are all code changes sufficiently tested?
- [X] Are there screenshots for UI changes?

![image](https://user-images.githubusercontent.com/71687298/204397935-f9bd475d-7394-4070-8400-1d6ecdb994a7.png)
![image](https://user-images.githubusercontent.com/71687298/204398471-578cfd30-fd9e-46c3-bd8a-bf666102a1cb.png)

