### PR TITLE
#447 Replace loading text on ProgramsPage with MUI CircularProgress

### DIFF
--- a/webapp/src/components/ProgramsPage.tsx
+++ b/webapp/src/components/ProgramsPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Container, Stack } from '@mui/material';
+import { CircularProgress, Container, Stack } from '@mui/material';
 
 import ProgramPicker from './ProgramPicker';
 import ProgramCalendar from './ProgramCalendar';
@@ -28,9 +28,13 @@ const ProgramsPage = () => {
   }
   if (isLoading) {
     return (
-      <Container fixed>
-        <div>Loading...</div>
-      </Container>
+      <Stack
+        alignItems="center"
+        justifyContent="center"
+        sx={{ height: '100vh' }}
+      >
+        <CircularProgress disableShrink />
+      </Stack>
     );
   }
   if (!programsList) {


### PR DESCRIPTION
## Proposed changes

This PR resolves #447 . It replaces the "Loading..." text on ProgramsPage with MUI's CircularProgress (spinner). I referred to the SessionContext page when I made the changes to the ProgramsPage. I noticed that the spinner was not as visible as I expected so I used `<CircularProgress disableShrink />` instead.

We should also expand the scope of this PR by replacing "Loading..." text on other pages as well. 

## Checklist

- [X] Are the issues being addressed linked to this PR?
- [X] Do all commit messages start with the issue number?
- [X] Are all code changes sufficiently tested?
- [X] Are there screenshots for UI changes?

![image](https://user-images.githubusercontent.com/71687298/204651107-bb7817cc-85be-4578-9998-cc0462ea776a.png)
