### PR TITLE
#448 add all day label to the calendar

### DIFF
--- a/webapp/src/components/ProgramCalendar.tsx
+++ b/webapp/src/components/ProgramCalendar.tsx
@@ -1,88 +1,78 @@
 import React from 'react';
 import { decodeHTML } from 'entities';
 import { DateTime } from 'luxon';
-import { Calendar, luxonLocalizer, Views,TimeGrid } from 'react-big-calendar';
+import { Calendar, luxonLocalizer, Views } from 'react-big-calendar';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
-import { useCallback, useMemo } from 'react';
- 
-import ProgramActivityDialog from './ProgramActivityDialog';
-import { useState } from 'react';
- 
-import {
- CalendarEvent,
- ProgramWithActivities,
- ProgramActivity,
-} from '../types/api';
- 
-interface ProgramCalendarProps {
- program: ProgramWithActivities;
-}
- 
-const activitiesForCalendar = (
- activities: ProgramActivity[]
-): CalendarEvent[] => {
- return activities.map(
-   activity =>
-     ({
-       title: decodeHTML(activity.title),
-       start: new Date(activity.start_time),
-       end: new Date(activity.end_time),
-       description: decodeHTML(activity.description_text),
-       allDay: !activity.duration,
-     } as CalendarEvent)
- );
-};
- 
-const ProgramCalendar = ({ program }: ProgramCalendarProps) => {
- const [dialogShow, setDialogShow] = React.useState(false);
- const [dialogContents, setDialogContents] = React.useState<CalendarEvent>({
-   title: '',
-   description: '',
-   allDay: false,
-   start: new Date(),
-   end: new Date(),
- });
- 
- const handleClickActivity = (activity: CalendarEvent) => {
-   setDialogShow(true);
-   setDialogContents(activity);
- };
- 
- // customize view
- const[view, setView] = useState();
-  const [currentView, setCurrentView] = React.useState<string>(Views.WEEK);
- const onView  = React.useCallback((newView: string): void => setCurrentView(newView), [setCurrentView]);
- 
- const TimeGutter = () => <p style={{textAlign:"center"}}>All Day</p>;
- 
- const closeDialog = () => setDialogShow(false);
- 
- return (
-   <>
-     <Calendar
-       events={activitiesForCalendar(program.activities)}
-       onSelectEvent={handleClickActivity}
-       localizer={luxonLocalizer(DateTime)}
-       defaultView={Views.WEEK}
-       onView={onView}
-       startAccessor="start"
-       endAccessor="end"
-       getNow={() => DateTime.local().toJSDate()}
-       scrollToTime={DateTime.local().set({ hour: 8, minute: 0 }).toJSDate()}
-       style={{ height: 500 }}
-       components={{
-         timeGutterHeader: TimeGutter,
-       }}
-     />
-     <ProgramActivityDialog
-       show={dialogShow}
-       contents={dialogContents}
-       handleClose={closeDialog}
-     />
-   </>
- );
-};
- 
-export default ProgramCalendar;
- 
 
+import ProgramActivityDialog from './ProgramActivityDialog';
+
+import {
+  CalendarEvent,
+  ProgramWithActivities,
+  ProgramActivity,
+} from '../types/api';
+
+interface ProgramCalendarProps {
+  program: ProgramWithActivities;
+}
+
+const activitiesForCalendar = (
+  activities: ProgramActivity[]
+): CalendarEvent[] => {
+  return activities.map(
+    activity =>
+      ({
+        title: decodeHTML(activity.title),
+        start: new Date(activity.start_time),
+        end: new Date(activity.end_time),
+        description: decodeHTML(activity.description_text),
+        allDay: !activity.duration,
+      } as CalendarEvent)
+  );
+};
+
+const ProgramCalendar = ({ program }: ProgramCalendarProps) => {
+  const [dialogShow, setDialogShow] = React.useState(false);
+  const [dialogContents, setDialogContents] = React.useState<CalendarEvent>({
+    title: '',
+    description: '',
+    allDay: false,
+    start: new Date(),
+    end: new Date(),
+  });
+
+  const handleClickActivity = (activity: CalendarEvent) => {
+    setDialogShow(true);
+    setDialogContents(activity);
+  };
+
+  const TimeGutter = () => <p style={{ textAlign: 'center' }}>All Day</p>;
+
+  const closeDialog = () => setDialogShow(false);
+
+  return (
+    <>
+      <Calendar
+        events={activitiesForCalendar(program.activities)}
+        onSelectEvent={handleClickActivity}
+        localizer={luxonLocalizer(DateTime)}
+        defaultView={Views.WEEK}
+        startAccessor="start"
+        endAccessor="end"
+        getNow={() => DateTime.local().toJSDate()}
+        scrollToTime={DateTime.local().set({ hour: 8, minute: 0 }).toJSDate()}
+        style={{ height: 500 }}
+        components={{
+          timeGutterHeader: TimeGutter,
+        }}
+      />
+      <ProgramActivityDialog
+        show={dialogShow}
+        contents={dialogContents}
+        handleClose={closeDialog}
+      />
+    </>
+  );
+};
+
+export default ProgramCalendar;

--- a/webapp/src/components/ProgramCalendar.tsx
+++ b/webapp/src/components/ProgramCalendar.tsx
@@ -1,73 +1,88 @@
 import React from 'react';
 import { decodeHTML } from 'entities';
 import { DateTime } from 'luxon';
-import { Calendar, luxonLocalizer, Views } from 'react-big-calendar';
+import { Calendar, luxonLocalizer, Views,TimeGrid } from 'react-big-calendar';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
-
+import { useCallback, useMemo } from 'react';
+ 
 import ProgramActivityDialog from './ProgramActivityDialog';
-
+import { useState } from 'react';
+ 
 import {
-  CalendarEvent,
-  ProgramWithActivities,
-  ProgramActivity,
+ CalendarEvent,
+ ProgramWithActivities,
+ ProgramActivity,
 } from '../types/api';
-
+ 
 interface ProgramCalendarProps {
-  program: ProgramWithActivities;
+ program: ProgramWithActivities;
 }
-
+ 
 const activitiesForCalendar = (
-  activities: ProgramActivity[]
+ activities: ProgramActivity[]
 ): CalendarEvent[] => {
-  return activities.map(
-    activity =>
-      ({
-        title: decodeHTML(activity.title),
-        start: new Date(activity.start_time),
-        end: new Date(activity.end_time),
-        description: decodeHTML(activity.description_text),
-        allDay: !activity.duration,
-      } as CalendarEvent)
-  );
+ return activities.map(
+   activity =>
+     ({
+       title: decodeHTML(activity.title),
+       start: new Date(activity.start_time),
+       end: new Date(activity.end_time),
+       description: decodeHTML(activity.description_text),
+       allDay: !activity.duration,
+     } as CalendarEvent)
+ );
 };
-
+ 
 const ProgramCalendar = ({ program }: ProgramCalendarProps) => {
-  const [dialogShow, setDialogShow] = React.useState(false);
-  const [dialogContents, setDialogContents] = React.useState<CalendarEvent>({
-    title: '',
-    description: '',
-    allDay: false,
-    start: new Date(),
-    end: new Date(),
-  });
-
-  const handleClickActivity = (activity: CalendarEvent) => {
-    setDialogShow(true);
-    setDialogContents(activity);
-  };
-
-  const closeDialog = () => setDialogShow(false);
-
-  return (
-    <>
-      <Calendar
-        events={activitiesForCalendar(program.activities)}
-        onSelectEvent={handleClickActivity}
-        localizer={luxonLocalizer(DateTime)}
-        defaultView={Views.WEEK}
-        startAccessor="start"
-        endAccessor="end"
-        getNow={() => DateTime.local().toJSDate()}
-        scrollToTime={DateTime.local().set({ hour: 8, minute: 0 }).toJSDate()}
-        style={{ height: 500 }}
-      />
-      <ProgramActivityDialog
-        show={dialogShow}
-        contents={dialogContents}
-        handleClose={closeDialog}
-      />
-    </>
-  );
+ const [dialogShow, setDialogShow] = React.useState(false);
+ const [dialogContents, setDialogContents] = React.useState<CalendarEvent>({
+   title: '',
+   description: '',
+   allDay: false,
+   start: new Date(),
+   end: new Date(),
+ });
+ 
+ const handleClickActivity = (activity: CalendarEvent) => {
+   setDialogShow(true);
+   setDialogContents(activity);
+ };
+ 
+ // customize view
+ const[view, setView] = useState();
+  const [currentView, setCurrentView] = React.useState<string>(Views.WEEK);
+ const onView  = React.useCallback((newView: string): void => setCurrentView(newView), [setCurrentView]);
+ 
+ const TimeGutter = () => <p style={{textAlign:"center"}}>All Day</p>;
+ 
+ const closeDialog = () => setDialogShow(false);
+ 
+ return (
+   <>
+     <Calendar
+       events={activitiesForCalendar(program.activities)}
+       onSelectEvent={handleClickActivity}
+       localizer={luxonLocalizer(DateTime)}
+       defaultView={Views.WEEK}
+       onView={onView}
+       startAccessor="start"
+       endAccessor="end"
+       getNow={() => DateTime.local().toJSDate()}
+       scrollToTime={DateTime.local().set({ hour: 8, minute: 0 }).toJSDate()}
+       style={{ height: 500 }}
+       components={{
+         timeGutterHeader: TimeGutter,
+       }}
+     />
+     <ProgramActivityDialog
+       show={dialogShow}
+       contents={dialogContents}
+       handleClose={closeDialog}
+     />
+   </>
+ );
 };
-
+ 
 export default ProgramCalendar;
+ 
+


### PR DESCRIPTION
## Proposed changes
Added "All Day" label to the week/day's view first row on the left.

<img width="1415" alt="Screen Shot 2022-11-30 at 1 02 40 PM" src="https://user-images.githubusercontent.com/45150411/204877132-2d684562-25ac-4584-9ee6-35567078dff8.png">

<img width="1415" alt="Screen Shot 2022-11-30 at 1 02 48 PM" src="https://user-images.githubusercontent.com/45150411/204877162-2761623c-aeb2-4776-a9dc-ddd11869d4c4.png">

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
