### PR TITLE
#446 Add options for addressing "back"/"home" button feedback

### DIFF
--- a/webapp/src/components/Navbar.tsx
+++ b/webapp/src/components/Navbar.tsx
@@ -9,8 +9,10 @@ import PeopleIcon from '@mui/icons-material/People';
 import MeetingsDrawerContext from './MeetingsDrawerContext';
 
 const StyledLogo = styled.span`
-  &:hover {
+  cursor: auto;
+  h1:hover {
     color: #1565c0;
+    cursor: pointer;
   }
 `;
 
@@ -19,9 +21,9 @@ const Navbar = () => {
   return (
     <Grid alignItems="center" container px={3}>
       <Grid item xs>
-        <Link to="/" style={{ textDecoration: 'none', color: 'black' }}>
+        <Link to="/" style={{ textDecoration: 'none', color: 'black'}}>
           <StyledLogo>
-            <h1>Rhizone</h1>
+            <h1 style={{height: '50px', width:'125px'}}>Rhizone</h1>
           </StyledLogo>
         </Link>
       </Grid>

--- a/webapp/src/components/Navbar.tsx
+++ b/webapp/src/components/Navbar.tsx
@@ -8,7 +8,7 @@ import PeopleIcon from '@mui/icons-material/People';
 
 import MeetingsDrawerContext from './MeetingsDrawerContext';
 
-const StyledLogo = styled.ul`
+const StyledLogo = styled.span`
   &:hover {
     color: #1565c0;
   }

--- a/webapp/src/components/Navbar.tsx
+++ b/webapp/src/components/Navbar.tsx
@@ -21,9 +21,9 @@ const Navbar = () => {
   return (
     <Grid alignItems="center" container px={3}>
       <Grid item xs>
-        <Link to="/" style={{ textDecoration: 'none', color: 'black'}}>
+        <Link to="/" style={{ textDecoration: 'none', color: 'black' }}>
           <StyledLogo>
-            <h1 style={{height: '50px', width:'125px'}}>Rhizone</h1>
+            <h1 style={{ height: '50px', width: '125px' }}>Rhizone</h1>
           </StyledLogo>
         </Link>
       </Grid>

--- a/webapp/src/components/Navbar.tsx
+++ b/webapp/src/components/Navbar.tsx
@@ -9,15 +9,17 @@ import PeopleIcon from '@mui/icons-material/People';
 import MeetingsDrawerContext from './MeetingsDrawerContext';
 
 const StyledLogo = styled.ul`
-  &:hover { color: blue }
-`
+  &:hover {
+    color: blue;
+  }
+`;
 
 const Navbar = () => {
   const { open: openMeetingsDrawer } = useContext(MeetingsDrawerContext);
   return (
     <Grid alignItems="center" container px={3}>
       <Grid item xs>
-        <Link to="/" style={{textDecoration: 'none', color: 'black'}}>
+        <Link to="/" style={{ textDecoration: 'none', color: 'black' }}>
           <StyledLogo>
             <h1>Rhizone</h1>
           </StyledLogo>

--- a/webapp/src/components/Navbar.tsx
+++ b/webapp/src/components/Navbar.tsx
@@ -1,11 +1,16 @@
 import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import { Button, Grid, IconButton } from '@mui/material';
+import styled from '@emotion/styled';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import HomeIcon from '@mui/icons-material/Home';
 import PeopleIcon from '@mui/icons-material/People';
 
 import MeetingsDrawerContext from './MeetingsDrawerContext';
+
+const StyledLogo = styled.ul`
+  &:hover { color: blue }
+`
 
 const Navbar = () => {
   const { open: openMeetingsDrawer } = useContext(MeetingsDrawerContext);
@@ -13,7 +18,9 @@ const Navbar = () => {
     <Grid alignItems="center" container px={3}>
       <Grid item xs>
         <Link to="/" style={{textDecoration: 'none', color: 'black'}}>
-          <h1>Rhizone</h1>
+          <StyledLogo>
+            <h1>Rhizone</h1>
+          </StyledLogo>
         </Link>
       </Grid>
       <Grid item xs="auto">

--- a/webapp/src/components/Navbar.tsx
+++ b/webapp/src/components/Navbar.tsx
@@ -10,7 +10,7 @@ import MeetingsDrawerContext from './MeetingsDrawerContext';
 
 const StyledLogo = styled.ul`
   &:hover {
-    color: blue;
+    color: #1565c0;
   }
 `;
 

--- a/webapp/src/components/Navbar.tsx
+++ b/webapp/src/components/Navbar.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import { Button, Grid, IconButton } from '@mui/material';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import HomeIcon from '@mui/icons-material/Home';
 import PeopleIcon from '@mui/icons-material/People';
 
 import MeetingsDrawerContext from './MeetingsDrawerContext';
@@ -11,11 +12,14 @@ const Navbar = () => {
   return (
     <Grid alignItems="center" container px={3}>
       <Grid item xs>
-        <Link to="/" style={{ textDecoration: 'none', color: 'black' }}>
+        <Link to="/" style={{textDecoration: 'none', color: 'black'}}>
           <h1>Rhizone</h1>
         </Link>
       </Grid>
       <Grid item xs="auto">
+        <IconButton sx={{ mr: 1 }} href="/">
+          <HomeIcon />
+        </IconButton>
         <IconButton sx={{ mr: 1 }} href="/calendar">
           <CalendarMonthIcon />
         </IconButton>


### PR DESCRIPTION
## Proposed changes

Add a home icon to the Navbar for the User to click and be rerouted to the home page.
Add styling to the Rhizone logo so when the user hover the mouse over it so they will be more aware that they can use the logo to go to the main page.

https://user-images.githubusercontent.com/98124157/204907165-ea8d1670-3c36-40b4-9064-8a7ad8d3d07b.mov

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
