### PR TITLE
#465 Refine the Dialog design

### DIFF
--- a/webapp/src/components/ProgramActivityDialog.tsx
+++ b/webapp/src/components/ProgramActivityDialog.tsx
@@ -8,6 +8,11 @@ import {
   DialogContentText,
   DialogTitle,
   Divider,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
 } from '@mui/material';
 
 import { formatDate, formatTime } from '../helpers/dateTime';
@@ -62,28 +67,64 @@ const ProgramActivityDialog = ({
     <Dialog
       open={show}
       onClose={handleClose}
+      maxWidth="xs"
       aria-labelledby="alert-dialog-title"
       aria-describedby="alert-dialog-description"
     >
-      <DialogTitle id="alert-dialog-title" sx={{ textAlign: 'center' }}>
+      <DialogTitle
+        id="alert-dialog-title"
+        sx={{ textAlign: 'center', fontWeight: 'bold' }}
+      >
         {contents.title}
       </DialogTitle>
 
       <Divider />
 
+      <DialogContent sx={{ textAlign: 'center' }}>
+        <DialogContentText>{timeRange()}</DialogContentText>
+      </DialogContent>
+      <Divider />
       <DialogContent>
-        <DialogContentText id="alert-dialog-description" sx={{ mb: 1 }}>
-          {timeRange()}
-        </DialogContentText>
-
-        <DialogContentText>
-          <strong>Program:</strong>
-          {contents.programTitle}
-        </DialogContentText>
-
-        <DialogContentText id="alert-dialog-description">
-          <strong>Description:</strong> {contents.description}
-        </DialogContentText>
+        <TableContainer>
+          <Table size="small">
+            <TableBody>
+              <TableRow>
+                <TableCell
+                  component="th"
+                  scope="row"
+                  sx={{
+                    fontWeight: 'bold',
+                    border: 'none',
+                    verticalAlign: 'top',
+                    textAlign: 'right',
+                  }}
+                >
+                  Program:
+                </TableCell>
+                <TableCell sx={{ border: 'none', fontWeight: 'bold' }}>
+                  {contents.programTitle}
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell
+                  component="th"
+                  scope="row"
+                  sx={{
+                    fontWeight: 'bold',
+                    border: 'none',
+                    verticalAlign: 'top',
+                    textAlign: 'right',
+                  }}
+                >
+                  Description:
+                </TableCell>
+                <TableCell sx={{ border: 'none' }}>
+                  {contents.description}
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
       </DialogContent>
 
       <Divider />


### PR DESCRIPTION
## Proposed changes

This makes some tweaks to the design of the Dialog to make it a little easier to read, ensuring consistent spacing and making it more flexible to extend in the future.

I was going to wrap the dates in HTML5 `<time>` elements, but I'm not sure that's the best approach as of now. I'll think about that later.

## UI changes

![newdialog](https://user-images.githubusercontent.com/4006420/205466501-2b828c64-2a33-46e5-8ee9-d89660e9bb73.png)

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
