### PR TITLE
#474 Add unique constraint to participant_activities

### DIFF
--- a/db/migration/V019__create_programs.sql
+++ b/db/migration/V019__create_programs.sql
@@ -68,6 +68,7 @@ CREATE TABLE participant_activities (
   FOREIGN KEY (activity_id) REFERENCES activities(id),
   INDEX participant_activities_principal_id (principal_id),
   FOREIGN KEY (principal_id) REFERENCES principals(id),
+  UNIQUE (program_id, activity_id, principal_id),
   PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
## Proposed changes

This resolves #474 by adding a unique constraint to the `participant_activities` table so that we can't possibly insert a duplicate combination of (program_id, activity_id, and participant_id) into the table.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
