### PR TITLE
#464 Add error handling to programsRouter GET function 

### DIFF
--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -63,5 +63,10 @@ describe('programsRouter', () => {
         done(err);
       });
     });
+
+    it('should respond with an internal server error if an error was thrown while listing programs', done => {
+      mockListProgramsWithActivities.mockRejectedValue(new Error());
+      appAgent.get('/').expect(500, done);
+    });
   });
 });

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -5,8 +5,14 @@ import { listProgramsWithActivities } from '../services/programsService';
 
 const programsRouter = Router();
 
-programsRouter.get('/', async (req, res) => {
-  const programsWithActivities = await listProgramsWithActivities();
+programsRouter.get('/', async (req, res, next) => {
+  let programsWithActivities;
+  try {
+    programsWithActivities = await listProgramsWithActivities();
+  } catch (error) {
+    next(error);
+    return;
+  }
   res.json(
     collectionEnvelope(programsWithActivities, programsWithActivities.length)
   );


### PR DESCRIPTION
## Proposed changes

This PR resolves #464 by adding error handling into the `programsRouter.get('/')` function. A respective test block was added to the programs router test file.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
