### PR TITLE
#454 Add service file functions to update `participant_activities` completion status

### DIFF
--- a/api/src/models.d.ts
+++ b/api/src/models.d.ts
@@ -55,7 +55,7 @@ export interface ActivityType {
   updated_at?: string;
 }
 
-export interface participantActivities {
+export interface ParticipantActivities {
   id: number;
   program_id: number;
   activity_id: number;

--- a/api/src/models.d.ts
+++ b/api/src/models.d.ts
@@ -54,3 +54,11 @@ export interface ActivityType {
   created_at?: string;
   updated_at?: string;
 }
+
+export interface participantActivities {
+  id: number;
+  program_id: number;
+  activity_id: number;
+  principal_id: number;
+  completed: boolean;
+}

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -441,12 +441,6 @@ describe('programsService', () => {
     it('should return false for an activity status not in the table', async () => {});
   });
 
-  describe('listParticipantActivitiesCompletionForProgram', () => {
-    it('should return a list of participant activities with their completion statuses', async () => {});
-    it('should return null if the programId does not exist', () => {});
-    it('should return null if the programId does not have any assignments', () => {});
-  });
-
   // TODO: tests for setParticipantActivityCompletion
   describe('setParticipantActivityCompletion', () => {
     it('should return the participant activity ID of an updated existing row in the table', async () => {});

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -293,8 +293,6 @@ const activityTypesList: ActivityType[] = [
   },
 ];
 
-// TODO: Define some example participant_activity data
-
 describe('programsService', () => {
   describe('listAllPrograms', () => {
     it('should list all available programs', async () => {

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -533,7 +533,7 @@ describe('programsService', () => {
           programId,
           activityId
         )
-      //).toEqual(false);
+        //).toEqual(false);
       ).toEqual({
         activityId: activityId,
         participantActivityId: 2,
@@ -553,13 +553,12 @@ describe('programsService', () => {
           programId,
           activityId
         )
-      //).toEqual(false);
+        //).toEqual(false);
       ).toEqual({
-        "activityId": 10, 
-        "completed": null, 
-        "participantActivityId": null
+        activityId: 10,
+        completed: null,
+        participantActivityId: null,
       });
-      
     });
   });
 
@@ -570,7 +569,7 @@ describe('programsService', () => {
     const activityId2 = 9;
     const completed = true;
     const newIndex = participantActivitiesList.length;
-
+    // TODO: should update it('')
     it('should return the participant activity ID of an updated existing row in the table', async () => {
       mockQuery(
         'select `id` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
@@ -588,6 +587,17 @@ describe('programsService', () => {
         ],
         [participantActivitiesList[0].id]
       );
+      mockQuery(
+        'select `activity_id`, `id`, `completed` from `participant_activities` where `id` = ?',
+        [participantActivitiesList[0].id],
+        [
+          {
+            activity_id: activityId,
+            id: participantActivitiesList[0].id,
+            completed: false,
+          },
+        ]
+      );
       expect(
         await setParticipantActivityCompletion(
           principalId,
@@ -595,7 +605,12 @@ describe('programsService', () => {
           activityId,
           completed
         )
-      ).toEqual(participantActivitiesList[0].id);
+        //).toEqual(participantActivitiesList[0].id);
+      ).toEqual({
+        activityId: activityId,
+        participantActivityId: participantActivitiesList[0].id,
+        completed: false,
+      });
     });
 
     it('should return the participant activity ID of an inserted row in the table', async () => {
@@ -614,6 +629,11 @@ describe('programsService', () => {
         [completed, newIndex, principalId, programId, activityId2],
         [newIndex]
       );
+      mockQuery(
+        'select `activity_id`, `id`, `completed` from `participant_activities` where `id` = ?',
+        [newIndex],
+        [{ activity_id: activityId2, id: newIndex, completed: false }]
+      );
       expect(
         await setParticipantActivityCompletion(
           principalId,
@@ -621,7 +641,12 @@ describe('programsService', () => {
           activityId2,
           completed
         )
-      ).toEqual(newIndex);
+        //).toEqual(newIndex);
+      ).toEqual({
+        activityId: activityId2,
+        participantActivityId: newIndex,
+        completed: false,
+      });
     });
   });
 });

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -486,6 +486,7 @@ describe('programsService', () => {
     const principalId = 3;
     const programId = 1;
     const activityId = 10;
+    // TODO: should update it('')
     it('should return true for a completed activity by a participant', async () => {
       mockQuery(
         'select `id` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
@@ -493,9 +494,11 @@ describe('programsService', () => {
         [{ id: 3 }]
       );
       mockQuery(
-        'select `completed` from `participant_activities` where `id` = ?',
+        //'select `completed` from `participant_activities` where `id` = ?',
+        'select `activity_id`, `id`, `completed` from `participant_activities` where `id` = ?',
         [3],
-        [{ completed: true }]
+        //[{ completed: true }]
+        [{ activity_id: activityId, id: 3, completed: true }]
       );
       expect(
         await getParticipantActivityCompletion(
@@ -504,7 +507,11 @@ describe('programsService', () => {
           activityId
         )
         //).toEqual(true);
-      ).toEqual(true);
+      ).toEqual({
+        activityId: activityId,
+        participantActivityId: 3,
+        completed: true,
+      });
     });
 
     it('should return false for an activity marked incomplete by participant', async () => {
@@ -514,9 +521,11 @@ describe('programsService', () => {
         [{ id: 2 }]
       );
       mockQuery(
-        'select `completed` from `participant_activities` where `id` = ?',
+        //'select `completed` from `participant_activities` where `id` = ?',
+        'select `activity_id`, `id`, `completed` from `participant_activities` where `id` = ?',
         [2],
-        [{ completed: false }]
+        //[{ completed: false }]
+        [{ activity_id: activityId, id: 2, completed: false }]
       );
       expect(
         await getParticipantActivityCompletion(
@@ -524,7 +533,12 @@ describe('programsService', () => {
           programId,
           activityId
         )
-      ).toEqual(false);
+      //).toEqual(false);
+      ).toEqual({
+        activityId: activityId,
+        participantActivityId: 2,
+        completed: false,
+      });
     });
 
     it('should return false for an activity status not in the table', async () => {
@@ -539,7 +553,13 @@ describe('programsService', () => {
           programId,
           activityId
         )
-      ).toEqual(false);
+      //).toEqual(false);
+      ).toEqual({
+        "activityId": 10, 
+        "completed": null, 
+        "participantActivityId": null
+      });
+      
     });
   });
 

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -266,6 +266,8 @@ const activityTypesList: ActivityType[] = [
   },
 ];
 
+// TODO: Define some example participant_activity data
+
 describe('programsService', () => {
   describe('listAllPrograms', () => {
     it('should list all available programs', async () => {
@@ -424,5 +426,24 @@ describe('programsService', () => {
         programsWithActivities
       );
     });
+  });
+
+  // TODO: tests for getParticipantActivityId
+  describe('getParticipantActivityId', () => {
+    it('should return the ID of an existing row in the table', async () => {});
+    it('should return null if requesting the ID of row that does not exist', async () => {});
+  });
+
+  // TODO: tests for getParticipantActivityCompletion
+  describe('getParticipantActivityCompletion', () => {
+    it('should return true for a completed activity by a participant', async () => {});
+    it('should return false for an activity marked incomplete by participant', async () => {});
+    it('should return false for an activity status not in the table', async () => {});
+  });
+
+  // TODO: tests for setParticipantActivityCompletion
+  describe('setParticipantActivityCompletion', () => {
+    it('should return the participant activity ID of an updated existing row in the table', async () => {});
+    it('should return the participant activity ID of an inserted row in the table', async () => {});
   });
 });

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -19,7 +19,7 @@ import {
   CurriculumActivity,
   ActivityType,
   ProgramWithActivities,
-  participantActivities,
+  ParticipantActivities,
 } from '../../models';
 
 import { mockQuery } from '../mockDb';
@@ -145,7 +145,7 @@ const curriculumActivitiesList: CurriculumActivity[] = [
     updated_at: '2022-11-15 01:23:45',
   },
 ];
-const participantActivitiesList: participantActivities[] = [
+const participantActivitiesList: ParticipantActivities[] = [
   {
     id: 1,
     program_id: 1,

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -145,6 +145,29 @@ const curriculumActivitiesList: CurriculumActivity[] = [
     updated_at: '2022-11-15 01:23:45',
   },
 ];
+const participantActivitiesList: participantActivities[] = [
+  {
+    id: 1,
+    program_id: 1,
+    activity_id: 7,
+    principal_id: 3,
+    completed: false,
+  },
+  {
+    id: 2,
+    program_id: 1,
+    activity_id: 8,
+    principal_id: 3,
+    completed: false,
+  },
+  {
+    id: 3,
+    program_id: 1,
+    activity_id: 10,
+    principal_id: 3,
+    completed: true,
+  },
+];
 const programActivitiesList: ProgramActivity[][] = [
   [
     {
@@ -431,30 +454,7 @@ describe('programsService', () => {
       );
     });
   });
-  const participantActivitiesList: participantActivities[] = [
-    {
-      id: 1,
-      program_id: 1,
-      activity_id: 7,
-      principal_id: 3,
-      completed: false,
-    },
-    {
-      id: 2,
-      program_id: 1,
-      activity_id: 8,
-      principal_id: 3,
-      completed: false,
-    },
-    {
-      id: 3,
-      program_id: 1,
-      activity_id: 10,
-      principal_id: 3,
-      completed: true,
-    },
-  ];
-  // TODO: tests for getParticipantActivityId
+
   describe('getParticipantActivityId', () => {
     const principalId = 3;
     const programId = 1;
@@ -469,6 +469,7 @@ describe('programsService', () => {
         await getParticipantActivityId(principalId, programId, activityId)
       ).toEqual(participantActivitiesList[0].id);
     });
+
     it('should return null if requesting the ID of row that does not exist', async () => {
       mockQuery(
         'select `id` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
@@ -481,63 +482,57 @@ describe('programsService', () => {
     });
   });
 
-  // TODO: tests for getParticipantActivityCompletion
   describe('getParticipantActivityCompletion', () => {
     const principalId = 3;
     const programId = 1;
     const activityId = 10;
     it('should return true for a completed activity by a participant', async () => {
-      const completed = true;
-      /*
       mockQuery(
         'select `id` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
-        [principalId, programId, activityId ],
-        [{id:3}]
+        [principalId, programId, activityId],
+        [{ id: 3 }]
       );
-*/
-      /*
       mockQuery(
         'select `completed` from `participant_activities` where `id` = ?',
         [3],
-        [true]
-        //['true']
+        [{ completed: true }]
       );
-*/
-      /* 
       expect(
-        await getParticipantActivityCompletion(principalId, programId, activityId)
+        await getParticipantActivityCompletion(
+          principalId,
+          programId,
+          activityId
+        )
+        //).toEqual(true);
       ).toEqual(true);
-*/
     });
+
     it('should return false for an activity marked incomplete by participant', async () => {
-      /*
       mockQuery(
         'select `id` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
-        [principalId, programId, activityId ],
-        [{id:2}]
+        [principalId, programId, activityId],
+        [{ id: 2 }]
       );
-*/
-      /*
       mockQuery(
         'select `completed` from `participant_activities` where `id` = ?',
         [2],
-        [false]
+        [{ completed: false }]
       );
-*/
-      /* 
       expect(
-        await getParticipantActivityCompletion(principalId, programId, activityId)
+        await getParticipantActivityCompletion(
+          principalId,
+          programId,
+          activityId
+        )
       ).toEqual(false);
-*/
     });
+
     it('should return false for an activity status not in the table', async () => {
-      /* */
       mockQuery(
         'select `id` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
         [principalId, programId, activityId],
         []
       );
-      /* */
       expect(
         await getParticipantActivityCompletion(
           principalId,
@@ -548,52 +543,65 @@ describe('programsService', () => {
     });
   });
 
-  // TODO: tests for setParticipantActivityCompletion
   describe('setParticipantActivityCompletion', () => {
     const principalId = 3;
     const programId = 1;
     const activityId = 7;
     const activityId2 = 9;
     const completed = true;
-    const participantActivityId = 1;
     const newIndex = participantActivitiesList.length;
-    /* 
+
     it('should return the participant activity ID of an updated existing row in the table', async () => {
       mockQuery(
         'select `id` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
         [principalId, programId, activityId],
-        [{id:participantActivitiesList[0].id}]
+        [{ id: participantActivitiesList[0].id }]
       );
       mockQuery(
         'update `participant_activities` set `completed` = ? where `id` = ? and `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
-        [completed, participantActivitiesList[0].id, principalId, programId, activityId],
+        [
+          completed,
+          participantActivitiesList[0].id,
+          principalId,
+          programId,
+          activityId,
+        ],
         [participantActivitiesList[0].id]
       );
       expect(
-        await setParticipantActivityCompletion(principalId, programId, activityId, completed)
+        await setParticipantActivityCompletion(
+          principalId,
+          programId,
+          activityId,
+          completed
+        )
       ).toEqual(participantActivitiesList[0].id);
     });
-    */
+
     it('should return the participant activity ID of an inserted row in the table', async () => {
-      /*
       mockQuery(
         'select `id` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
         [principalId, programId, activityId2],
         [null]
       );
-      */
-      /*
       mockQuery(
-        'insert into `participant_activities` (`principal_id`, `program_id`, `activity_id`, `completed`) values (?, ?, ?, ?)',
-        [principalId, programId, activityId2, completed],
+        'insert into `participant_activities` (`activity_id`, `completed`, `principal_id`, `program_id`) values (?, ?, ?, ?)',
+        [activityId2, false, principalId, programId],
         [newIndex]
       );
-      */
-      /*
+      mockQuery(
+        'update `participant_activities` set `completed` = ? where `id` = ? and `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
+        [completed, newIndex, principalId, programId, activityId2],
+        [newIndex]
+      );
       expect(
-        await setParticipantActivityCompletion(principalId, programId, activityId2, completed)
+        await setParticipantActivityCompletion(
+          principalId,
+          programId,
+          activityId2,
+          completed
+        )
       ).toEqual(newIndex);
-      */
     });
   });
 });

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -9,6 +9,9 @@ import {
   findProgramWithActivities,
   listProgramsForCurriculum,
   listProgramsWithActivities,
+  getParticipantActivityId,
+  getParticipantActivityCompletion,
+  setParticipantActivityCompletion,
 } from '../programsService';
 import {
   Program,
@@ -16,6 +19,7 @@ import {
   CurriculumActivity,
   ActivityType,
   ProgramWithActivities,
+  participantActivities,
 } from '../../models';
 
 import { mockQuery } from '../mockDb';
@@ -427,23 +431,169 @@ describe('programsService', () => {
       );
     });
   });
-
+  const participantActivitiesList: participantActivities[] = [
+    {
+      id: 1,
+      program_id: 1,
+      activity_id: 7,
+      principal_id: 3,
+      completed: false,
+    },
+    {
+      id: 2,
+      program_id: 1,
+      activity_id: 8,
+      principal_id: 3,
+      completed: false,
+    },
+    {
+      id: 3,
+      program_id: 1,
+      activity_id: 10,
+      principal_id: 3,
+      completed: true,
+    },
+  ];
   // TODO: tests for getParticipantActivityId
   describe('getParticipantActivityId', () => {
-    it('should return the ID of an existing row in the table', async () => {});
-    it('should return null if requesting the ID of row that does not exist', async () => {});
+    const principalId = 3;
+    const programId = 1;
+    const activityId = 7;
+    it('should return the ID of an existing row in the table', async () => {
+      mockQuery(
+        'select `id` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
+        [principalId, programId, activityId],
+        [{ id: participantActivitiesList[0].id }]
+      );
+      expect(
+        await getParticipantActivityId(principalId, programId, activityId)
+      ).toEqual(participantActivitiesList[0].id);
+    });
+    it('should return null if requesting the ID of row that does not exist', async () => {
+      mockQuery(
+        'select `id` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
+        [principalId, programId, activityId],
+        []
+      );
+      expect(
+        await getParticipantActivityId(principalId, programId, activityId)
+      ).toEqual(null);
+    });
   });
 
   // TODO: tests for getParticipantActivityCompletion
   describe('getParticipantActivityCompletion', () => {
-    it('should return true for a completed activity by a participant', async () => {});
-    it('should return false for an activity marked incomplete by participant', async () => {});
-    it('should return false for an activity status not in the table', async () => {});
+    const principalId = 3;
+    const programId = 1;
+    const activityId = 10;
+    it('should return true for a completed activity by a participant', async () => {
+      const completed = true;
+      /*
+      mockQuery(
+        'select `id` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
+        [principalId, programId, activityId ],
+        [{id:3}]
+      );
+*/
+      /*
+      mockQuery(
+        'select `completed` from `participant_activities` where `id` = ?',
+        [3],
+        [true]
+        //['true']
+      );
+*/
+      /* 
+      expect(
+        await getParticipantActivityCompletion(principalId, programId, activityId)
+      ).toEqual(true);
+*/
+    });
+    it('should return false for an activity marked incomplete by participant', async () => {
+      /*
+      mockQuery(
+        'select `id` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
+        [principalId, programId, activityId ],
+        [{id:2}]
+      );
+*/
+      /*
+      mockQuery(
+        'select `completed` from `participant_activities` where `id` = ?',
+        [2],
+        [false]
+      );
+*/
+      /* 
+      expect(
+        await getParticipantActivityCompletion(principalId, programId, activityId)
+      ).toEqual(false);
+*/
+    });
+    it('should return false for an activity status not in the table', async () => {
+      /* */
+      mockQuery(
+        'select `id` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
+        [principalId, programId, activityId],
+        []
+      );
+      /* */
+      expect(
+        await getParticipantActivityCompletion(
+          principalId,
+          programId,
+          activityId
+        )
+      ).toEqual(false);
+    });
   });
 
   // TODO: tests for setParticipantActivityCompletion
   describe('setParticipantActivityCompletion', () => {
-    it('should return the participant activity ID of an updated existing row in the table', async () => {});
-    it('should return the participant activity ID of an inserted row in the table', async () => {});
+    const principalId = 3;
+    const programId = 1;
+    const activityId = 7;
+    const activityId2 = 9;
+    const completed = true;
+    const participantActivityId = 1;
+    const newIndex = participantActivitiesList.length;
+    /* 
+    it('should return the participant activity ID of an updated existing row in the table', async () => {
+      mockQuery(
+        'select `id` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
+        [principalId, programId, activityId],
+        [{id:participantActivitiesList[0].id}]
+      );
+      mockQuery(
+        'update `participant_activities` set `completed` = ? where `id` = ? and `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
+        [completed, participantActivitiesList[0].id, principalId, programId, activityId],
+        [participantActivitiesList[0].id]
+      );
+      expect(
+        await setParticipantActivityCompletion(principalId, programId, activityId, completed)
+      ).toEqual(participantActivitiesList[0].id);
+    });
+    */
+    it('should return the participant activity ID of an inserted row in the table', async () => {
+      /*
+      mockQuery(
+        'select `id` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
+        [principalId, programId, activityId2],
+        [null]
+      );
+      */
+      /*
+      mockQuery(
+        'insert into `participant_activities` (`principal_id`, `program_id`, `activity_id`, `completed`) values (?, ?, ?, ?)',
+        [principalId, programId, activityId2, completed],
+        [newIndex]
+      );
+      */
+      /*
+      expect(
+        await setParticipantActivityCompletion(principalId, programId, activityId2, completed)
+      ).toEqual(newIndex);
+      */
+    });
   });
 });

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -441,6 +441,12 @@ describe('programsService', () => {
     it('should return false for an activity status not in the table', async () => {});
   });
 
+  describe('listParticipantActivitiesCompletionForProgram', () => {
+    it('should return a list of participant activities with their completion statuses', async () => {});
+    it('should return null if the programId does not exist', () => {});
+    it('should return null if the programId does not have any assignments', () => {});
+  });
+
   // TODO: tests for setParticipantActivityCompletion
   describe('setParticipantActivityCompletion', () => {
     it('should return the participant activity ID of an updated existing row in the table', async () => {});

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -290,43 +290,20 @@ export const listProgramsWithActivities = async () => {
   return programsWithActivities;
 };
 
-// return CompletionStatus (a boolean value, true or false)
-export const getCompletionStatus = async (
-  participantActivityId: number
-) => {
-  const isCompleted =  await db('participant_activities')
-    .select('completed')
-    .where({participantActivityId});
-  return Boolean(isCompleted)
-
-};
-/*
-export const getCompletionStatus = async (
-  principalId: number,
-  programId: number,
-  activityId: number
-) => {
-   return await db('participant_activities')
-    .select('completed')
-    .where({ principalId, programId, activityId});
-};
-*/
-
-
 // return participantActivityId
-export const getParticipantActivityId = async (
+const getParticipantActivityId = async (
   principalId: number,
   programId: number,
   activityId: number
 ) => {
   let participantActivityId: number;
 
-  // if participant_activitie exists, get participantActivityId
+  // if participant_activity exists, get participantActivityId
   [participantActivityId] = await db('participant_activities')
     .select('id')
     .where({ principalId, programId, activityId});
 
-  // if participant_activitie doesn't exist, create one
+  // if participant_activity doesn't exist, create one
   if(!participantActivityId){
     await db.transaction(async trx => {
       [participantActivityId] = await trx('participant_activities').insert({
@@ -339,15 +316,31 @@ export const getParticipantActivityId = async (
   return { id: participantActivityId };
 };
 
-export const toggleCompletionStatus = async (
-  id: number,
+// getter -return CompletionStatus (a boolean value, true or false)
+export const getParticipantActivityCompletion = async (
+  principalId: number,
+  programId: number,
+  activityId: number,
+) => {
+  const participantActivityId = await getParticipantActivityId(principalId, programId, activityId);
+  const isCompleted =  await db('participant_activities')
+    .select('completed')
+    .where({id: participantActivityId});
+  return Boolean(isCompleted)
+};
+
+// setter
+export const setParticipantActivityCompletion = async (
   principalId: number,
   programId: number,
   activityId: number,
   completed:boolean
 ) => {
+  const participantActivityId = await getParticipantActivityId(principalId, programId, activityId);
   await db('participant_activities')
-    .where({ id, principalId, programId, activityId })
+    .where({ participantActivityId, principalId, programId, activityId })
     .update({ completed: !completed });
 };
+
+
 

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -290,25 +290,38 @@ export const listProgramsWithActivities = async () => {
   return programsWithActivities;
 };
 
-// return an activity? or only CompletionStatus?
-export const getActivityWithCompletionStatus = async (
+// return CompletionStatus (a boolean value, true or false)
+export const getCompletionStatus = async (
+  participantActivityId: number
+) => {
+  const isCompleted =  await db('participant_activities')
+    .select('completed')
+    .where({participantActivityId});
+  return Boolean(isCompleted)
+
+};
+/*
+export const getCompletionStatus = async (
   principalId: number,
   programId: number,
   activityId: number
 ) => {
    return await db('participant_activities')
-    .select('id','program_id', 'activity_id', 'principal_id', 'completed')
+    .select('completed')
     .where({ principalId, programId, activityId});
 };
+*/
 
-export const createParticipantActivity = async (
+
+// return participantActivityId
+export const getParticipantActivityId = async (
   principalId: number,
   programId: number,
   activityId: number
 ) => {
   let participantActivityId: number;
 
-  // check if participant_activitie exists
+  // if participant_activitie exists, get participantActivityId
   [participantActivityId] = await db('participant_activities')
     .select('id')
     .where({ principalId, programId, activityId});
@@ -330,11 +343,9 @@ export const toggleCompletionStatus = async (
   id: number,
   principalId: number,
   programId: number,
-  activityId: number
+  activityId: number,
+  completed:boolean
 ) => {
-  const [completed] = await db('participant_activities')
-    .select('completed')
-    .where({ id, principalId, programId, activityId});
   await db('participant_activities')
     .where({ id, principalId, programId, activityId })
     .update({ completed: !completed });

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -322,7 +322,7 @@ export const getParticipantActivityId = async (
  * @param {number} programId - the id for the unique program
  * @param {number} activityId - the id for the unique activity
  * @returns {boolean} - return true if the specific activity is completed,
- *    return false when either completion status is false or row in
+ *    return false when either completion status is false or any row in
  *    `participant_activities` table doesn't exist
  */
 export const getParticipantActivityCompletion = async (
@@ -335,13 +335,15 @@ export const getParticipantActivityCompletion = async (
     programId,
     activityId
   );
+  console.log('getter participantActivityId:', participantActivityId);
   if (!participantActivityId) return false;
   const [{ completed }] = await db('participant_activities')
     .select('completed')
     .where({ id: participantActivityId });
   // TODO: Fix the following line in case what we get back from the database
   // isn't exactly a string with the value of "true" or "false"
-  return completed === 'true';
+  //return completed === 'true';
+  return Boolean(completed);
 };
 
 /**
@@ -367,6 +369,8 @@ export const setParticipantActivityCompletion = async (
     programId,
     activityId
   );
+  //console.log('HI participantActivityId:',participantActivityId);
+
   if (!participantActivityId) {
     await db.transaction(async trx => {
       [participantActivityId] = await trx('participant_activities').insert({
@@ -386,5 +390,7 @@ export const setParticipantActivityCompletion = async (
       })
       .update({ completed: completed });
   }
+  //console.log('after insert -  participantActivityId:',participantActivityId);
+
   return participantActivityId;
 };

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -302,7 +302,6 @@ export const getParticipantActivityId = async (
   programId: number,
   activityId: number
 ) => {
-  let participantActivityId: number;
   // if participant_activity exists, get participantActivityId
   const [participantActivity] = await db('participant_activities')
     .select('id')
@@ -312,8 +311,7 @@ export const getParticipantActivityId = async (
       activity_id: activityId,
     });
   if (!participantActivity) return null; // when participantActivity is undefined
-  participantActivityId = participantActivity.id;
-  return participantActivityId;
+  return participantActivity.id;
 };
 
 /**

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -345,26 +345,6 @@ export const getParticipantActivityCompletion = async (
 };
 
 /**
- * Get the completion status (either true or false) of all activities of type assignment in a given program.
- *
- * @param {number} principalId - the unique id for the user
- * @param {number} programId - the id for the unique program
- * @returns List of activities and their completion statuses,
- *   or null if programId doesn't exist or it doesn't have activities
- *   of type "assignment"
- */
-export const listParticipantActivitiesCompletionForProgram = async (
-  principalId: number,
-  programId: number
-) => {
-  // TODO: get list of all activities in program where activity_type_id is assignment (you'll need a join statement here)
-  // TODO: get all `participant_activities` records for the principalId and programId
-  // TODO: match up the two lists and generate the return list
-  // TODO: return list should be an array of objects that look like this:
-  // { programId: number, activityId: number, completed: boolean }
-};
-
-/**
  * Set/Update the completion status of the specific activity. If the
  * `participant_activities` record doesn't exist, create it.
  *

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -335,11 +335,27 @@ export const getParticipantActivityCompletion = async (
     programId,
     activityId
   );
-  if (!participantActivityId) return false;
+  //if (!participantActivityId) return false;
+  if (!participantActivityId)
+    return {
+      activityId: activityId,
+      participantActivityId: null,
+      completed: null,
+    };
+  /*
   const [{ completed }] = await db('participant_activities')
     .select('completed')
     .where({ id: participantActivityId });
-  return Boolean(completed);
+  */
+  const [participantActivity] = await db('participant_activities')
+    .select('activity_id', 'id', 'completed')
+    .where({ id: participantActivityId });
+  //return Boolean(completed);
+  return {
+    activityId: activityId,
+    participantActivityId: participantActivityId,
+    completed: Boolean(participantActivity.completed),
+  };
 };
 
 /**

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -397,5 +397,13 @@ export const setParticipantActivityCompletion = async (
       activity_id: activityId,
     })
     .update({ completed: completed });
-  return participantActivityId;
+  const [participantActivity] = await db('participant_activities')
+    .select('activity_id', 'id', 'completed')
+    .where({ id: participantActivityId });
+  //return participantActivityId;
+  return {
+    activityId: activityId,
+    participantActivityId: participantActivityId,
+    completed: Boolean(participantActivity.completed),
+  };
 };

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -292,12 +292,12 @@ export const listProgramsWithActivities = async () => {
 
 /**
  * Get the id of the row in the `participant_activities` table that belongs to
- * the given user, program, and activity if it exists, Otherwise, , otherwise returns null.
+ * the given user, program, and activity if it exists, Otherwise it returns null.
  *
  * @param {number} principalId - the unique id for the user
  * @param {number} programId - the id for the unique program
  * @param {number} activityId - the id for the unique activity
- * @returns - either id of matching row in the table, if it exists or null
+ * @returns - Either id of matching row in the table or null if participantActivity doesn't exists
  */
 export const getParticipantActivityId = async (
   principalId: number,
@@ -321,7 +321,8 @@ export const getParticipantActivityId = async (
  * @param {number} principalId - the unique id for the user
  * @param {number} programId - the id for the unique program
  * @param {number} activityId - the id for the unique activity
- * @returns {Object} - if successful, the completed status
+ * @returns {Object} - return the completion status (true or false) of the activity by the given participantActivityId.
+ *                     If participantActivityId doesn't exist, the completion status is false.
  */
 export const getParticipantActivityCompletion = async (
   principalId: number,
@@ -343,16 +344,16 @@ export const getParticipantActivityCompletion = async (
 };
 
 /**
- * Set/Update the completion status of the specific activity. If the
- * `participant_activities` record doesn't exist, create it.
+ *  Set/Update the completion status of the specific activity.
+ *  Insert a new row and if conflict occurs which means it already has a row matching 'program_id', 'principal_id', 'activity_id',
+ *  then .merge({}) to update with 'completed' field to what we received from a user.
  *
  * @param {number} principalId - the unique id for the user
  * @param {number} programId - the id for the unique program
  * @param {number} activityId - the id for the unique activity
  * @param {boolean} completed - the boolean value that a user wants to set
  *    into the completed field
- * @returns {Object} - if successful, the ID of the record in the table
- *    that was updated/inserted and the completed status
+ * @returns {Object} - return the participantActivityId and the completion status (true or false) of an inserted row in the table
  */
 export const setParticipantActivityCompletion = async (
   principalId: number,

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -301,8 +301,13 @@ const getParticipantActivityId = async (
   // if participant_activity exists, get participantActivityId
   [participantActivityId] = await db('participant_activities')
     .select('id')
-    .where({ principalId, programId, activityId });
-  if (participantActivityId) return false;
+    .where({
+      principal_id: principalId,
+      program_id: programId,
+      activity_id: activityId,
+    });
+
+  if (!participantActivityId) return null;
 
   return { id: participantActivityId };
 };
@@ -325,12 +330,19 @@ export const getParticipantActivityCompletion = async (
     programId,
     activityId
   );
-  if (!participantActivityId) return;
+  console.log(participantActivityId);
+
+  if (!participantActivityId) return { status: false }; //future note: need to be updated once we work on the color tag feture
   const [completed]: boolean[] = await db('participant_activities')
     .select('completed')
     .where({ id: participantActivityId });
-  return Boolean(completed);
+  //return Boolean(completed);
+  return { status: completed };
 };
+
+// for the future feature: having different color based on the status, type....
+// return status for all activities
+//export getParticipantActivities =
 
 // setter
 export const setParticipantActivityCompletion = async (

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -338,7 +338,7 @@ export const getParticipantActivityCompletion = async (
     .select('activity_id', 'id', 'completed')
     .where({ id: participantActivityId });
   return {
-    completed: (participantActivity.completed === 1),
+    completed: participantActivity.completed === 1,
   };
 };
 
@@ -360,14 +360,17 @@ export const setParticipantActivityCompletion = async (
   activityId: number,
   completed: boolean
 ) => {
-  const [participantActivityRow] = await db('participant_activities').insert({
-    principal_id: principalId,
-    program_id: programId,
-    activity_id: activityId,
-    completed: completed,
-  }).onConflict(['program_id', 'principal_id', 'activity_id']).merge({completed: completed});
+  const [participantActivityRow] = await db('participant_activities')
+    .insert({
+      principal_id: principalId,
+      program_id: programId,
+      activity_id: activityId,
+      completed: completed,
+    })
+    .onConflict(['program_id', 'principal_id', 'activity_id'])
+    .merge({ completed: completed });
   return {
     participantActivityId: participantActivityRow.id,
-    completed: (participantActivityRow.completed === 1),
+    completed: participantActivityRow.completed === 1,
   };
 };

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -292,12 +292,12 @@ export const listProgramsWithActivities = async () => {
 
 /**
  * Get the id of the row in the `participant_activities` table that belongs to
- * the given user, program, and activity.
+ * the given user, program, and activity if it exists, Otherwise, , otherwise returns null.
  *
  * @param {number} principalId - the unique id for the user
  * @param {number} programId - the id for the unique program
  * @param {number} activityId - the id for the unique activity
- * @returns {number} - id of matching row in the table, if it exists
+ * @returns - either id of matching row in the table, if it exists or null
  */
 export const getParticipantActivityId = async (
   principalId: number,

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -335,14 +335,10 @@ export const getParticipantActivityCompletion = async (
     programId,
     activityId
   );
-  console.log('getter participantActivityId:', participantActivityId);
   if (!participantActivityId) return false;
   const [{ completed }] = await db('participant_activities')
     .select('completed')
     .where({ id: participantActivityId });
-  // TODO: Fix the following line in case what we get back from the database
-  // isn't exactly a string with the value of "true" or "false"
-  //return completed === 'true';
   return Boolean(completed);
 };
 
@@ -369,28 +365,21 @@ export const setParticipantActivityCompletion = async (
     programId,
     activityId
   );
-  //console.log('HI participantActivityId:',participantActivityId);
-
   if (!participantActivityId) {
-    await db.transaction(async trx => {
-      [participantActivityId] = await trx('participant_activities').insert({
-        principal_id: principalId,
-        program_id: programId,
-        activity_id: activityId,
-        completed,
-      });
+    [participantActivityId] = await db('participant_activities').insert({
+      principal_id: principalId,
+      program_id: programId,
+      activity_id: activityId,
+      completed: false,
     });
-  } else {
-    await db('participant_activities')
-      .where({
-        id: participantActivityId,
-        principal_id: principalId,
-        program_id: programId,
-        activity_id: activityId,
-      })
-      .update({ completed: completed });
   }
-  //console.log('after insert -  participantActivityId:',participantActivityId);
-
+  await db('participant_activities')
+    .where({
+      id: participantActivityId,
+      principal_id: principalId,
+      program_id: programId,
+      activity_id: activityId,
+    })
+    .update({ completed: completed });
   return participantActivityId;
 };

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -321,7 +321,7 @@ export const getParticipantActivityId = async (
  * @param {number} principalId - the unique id for the user
  * @param {number} programId - the id for the unique program
  * @param {number} activityId - the id for the unique activity
- * @returns {boolean}  - return true if the specific activity is completed,
+ * @returns {boolean} - return true if the specific activity is completed,
  *    return false when either completion status is false or row in
  *    `participant_activities` table doesn't exist
  */
@@ -339,7 +339,29 @@ export const getParticipantActivityCompletion = async (
   const [{ completed }] = await db('participant_activities')
     .select('completed')
     .where({ id: participantActivityId });
+  // TODO: Fix the following line in case what we get back from the database
+  // isn't exactly a string with the value of "true" or "false"
   return completed === 'true';
+};
+
+/**
+ * Get the completion status (either true or false) of all activities of type assignment in a given program.
+ *
+ * @param {number} principalId - the unique id for the user
+ * @param {number} programId - the id for the unique program
+ * @returns List of activities and their completion statuses,
+ *   or null if programId doesn't exist or it doesn't have activities
+ *   of type "assignment"
+ */
+export const listParticipantActivitiesCompletionForProgram = async (
+  principalId: number,
+  programId: number
+) => {
+  // TODO: get list of all activities in program where activity_type_id is assignment (you'll need a join statement here)
+  // TODO: get all `participant_activities` records for the principalId and programId
+  // TODO: match up the two lists and generate the return list
+  // TODO: return list should be an array of objects that look like this:
+  // { programId: number, activityId: number, completed: boolean }
 };
 
 /**

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -289,3 +289,54 @@ export const listProgramsWithActivities = async () => {
 
   return programsWithActivities;
 };
+
+// return an activity? or only CompletionStatus?
+export const getActivityWithCompletionStatus = async (
+  principalId: number,
+  programId: number,
+  activityId: number
+) => {
+   return await db('participant_activities')
+    .select('id','program_id', 'activity_id', 'principal_id', 'completed')
+    .where({ principalId, programId, activityId});
+};
+
+export const createParticipantActivity = async (
+  principalId: number,
+  programId: number,
+  activityId: number
+) => {
+  let participantActivityId: number;
+
+  // check if participant_activitie exists
+  [participantActivityId] = await db('participant_activities')
+    .select('id')
+    .where({ principalId, programId, activityId});
+
+  // if participant_activitie doesn't exist, create one
+  if(!participantActivityId){
+    await db.transaction(async trx => {
+      [participantActivityId] = await trx('participant_activities').insert({
+        principal_id: principalId,
+        program_id: programId,
+        activity_id: activityId,
+      })
+    });
+  }
+  return { id: participantActivityId };
+};
+
+export const toggleCompletionStatus = async (
+  id: number,
+  principalId: number,
+  programId: number,
+  activityId: number
+) => {
+  const [completed] = await db('participant_activities')
+    .select('completed')
+    .where({ id, principalId, programId, activityId});
+  await db('participant_activities')
+    .where({ id, principalId, programId, activityId })
+    .update({ completed: !completed });
+};
+


### PR DESCRIPTION
## Proposed changes
This resolves  #454 by:
- A `getParticipantActivityId` function returns the participant activity ID if it exists, otherwise it returns null.
- A `getParticipantActivityCompletion` function returns the completion status (either true or false) of the specific activity.
- A `setParticipantActivityCompletion` function is to set/update the completion status of the specific activity.
-  The JsDoc function headers for each of functions above.
-  The JEST test functions for each of functions above.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [ ] Are there screenshots for UI changes?