### PR TITLE
#471 Change the colour of all-day activities

### DIFF
--- a/webapp/src/components/ProgramCalendar.tsx
+++ b/webapp/src/components/ProgramCalendar.tsx
@@ -75,20 +75,6 @@ const ProgramCalendar = ({ program }: ProgramCalendarProps) => {
       };
     }
 
-    if (event.allDay && currentView === 'week') {
-      style = {
-        height: '190%',
-        backgroundColor: 'midnightblue',
-      };
-    }
-
-    if (event.allDay && currentView === 'day') {
-      style = {
-        height: '220%',
-        backgroundColor: 'midnightblue',
-      };
-    }
-
     return { style: style };
   };
 

--- a/webapp/src/components/ProgramCalendar.tsx
+++ b/webapp/src/components/ProgramCalendar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React from 'react';
 import { decodeHTML } from 'entities';
 import { DateTime } from 'luxon';
 import { Calendar, luxonLocalizer, Views } from 'react-big-calendar';

--- a/webapp/src/components/ProgramCalendar.tsx
+++ b/webapp/src/components/ProgramCalendar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import { decodeHTML } from 'entities';
 import { DateTime } from 'luxon';
 import { Calendar, luxonLocalizer, Views } from 'react-big-calendar';
@@ -69,6 +69,26 @@ const ProgramCalendar = ({ program }: ProgramCalendarProps) => {
         minHeight: '4%',
       };
     }
+    if (event.allDay && currentView !== 'agenda') {
+      style = {
+        backgroundColor: 'midnightblue',
+      };
+    }
+
+    if (event.allDay && currentView === 'week') {
+      style = {
+        height: '190%',
+        backgroundColor: 'midnightblue',
+      };
+    }
+
+    if (event.allDay && currentView === 'day') {
+      style = {
+        height: '220%',
+        backgroundColor: 'midnightblue',
+      };
+    }
+
     return { style: style };
   };
 


### PR DESCRIPTION
## Proposed changes
The colour and height of all day activity updated in the calendar.

<img width="1254" alt="Screen Shot 2022-12-07 at 8 50 34 PM" src="https://user-images.githubusercontent.com/45150411/206336902-da257175-a312-4d26-ac30-d979b00759a6.png">
<img width="1254" alt="Screen Shot 2022-12-07 at 8 34 50 PM" src="https://user-images.githubusercontent.com/45150411/206336939-fb074ae7-4ea9-452e-b4fd-5a92f4fe5306.png">
<img width="1254" alt="Screen Shot 2022-12-07 at 8 52 37 PM" src="https://user-images.githubusercontent.com/45150411/206336966-3cf4ac90-1fd0-4dde-8f34-cf388586f30a.png">

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
