### PR TITLE
#455 programs router supports retrieval and updating of participant activities completion status

### DIFF
--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -3,6 +3,7 @@ import {
   listProgramsWithActivities,
   getParticipantActivityId,
   getParticipantActivityCompletion,
+  setParticipantActivityCompletion,
 } from '../../services/programsService';
 import { createAppAgentForRouter, mockPrincipalId } from '../routerTestUtils';
 import programsRouter from '../programsRouter';
@@ -13,6 +14,9 @@ const mockListProgramsWithActivities = jest.mocked(listProgramsWithActivities);
 const mockGetParticipantActivityId = jest.mocked(getParticipantActivityId);
 const mockGetParticipantActivityCompletion = jest.mocked(
   getParticipantActivityCompletion
+);
+const mockSetParticipantActivityCompletion = jest.mocked(
+  setParticipantActivityCompletion
 );
 
 describe('programsRouter', () => {
@@ -91,6 +95,7 @@ describe('programsRouter', () => {
       appAgent
         .get(`/activityStatus/${programId}/${activityId}`)
         .expect(200, itemEnvelope({ status: false }), err => {
+          // should there be an expectation here for getParticipantActivityId to have been called as well?
           expect(mockGetParticipantActivityCompletion).toHaveBeenCalledWith(
             principalId,
             programId,
@@ -106,6 +111,33 @@ describe('programsRouter', () => {
   describe('PUT /activityStatus/:programId/:activityId', () => {
     it('should respond with a program activity completion status', done => {
       // see competenciesRouter test L119 for PUT/setter function test example
+      const principalId = 1;
+      const programId = 1;
+      const activityId = 1;
+      const participantActivity = { id: 1, completed: false };
+
+      mockPrincipalId(principalId);
+      mockGetParticipantActivityId.mockResolvedValue({
+        id: participantActivity.id,
+      });
+      mockSetParticipantActivityCompletion.mockResolvedValue({
+        id: 1,
+        completed: true,
+      });
+      appAgent
+        .put(`/activityStatus/${programId}/${activityId}`)
+        .send({
+          "completed": true,
+        })
+        .expect(200, err => {
+          // should there be an expectation here for getParticipantActivityId to have been called as well?
+          expect(mockSetParticipantActivityCompletion).toHaveBeenCalledWith(
+            principalId,
+            programId,
+            activityId
+          );
+          done(err);
+        });
     });
   });
 

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -124,6 +124,16 @@ describe('programsRouter', () => {
         // should this include a check for the error message content? programsRouter L36
     });
 
+    it('should respond with a bad request error if given an invalid activity id', done => {
+      const programId = 1;
+      const activityId = 0;
+
+      appAgent
+        .get(`/activityStatus/${programId}/${activityId}`)
+        .expect(400, done);
+        // should this include a check for the error message content? programsRouter L36
+    });
+
     it('should respond with an internal server error if an error was thrown while getting participant activity completion status', done => {
       const programId = 1;
       const activityId = 1;
@@ -168,6 +178,19 @@ describe('programsRouter', () => {
     it('should respond with a bad request error if given an invalid program id', done => {
       const programId = 0;
       const activityId = 1;
+
+      appAgent
+        .put(`/activityStatus/${programId}/${activityId}`)
+        .send({
+          completed: true,
+        })
+        .expect(400, done);
+        // should this include a check for the error message content? programsRouter L79
+    });
+
+    it('should respond with a bad request error if given an invalid activity id', done => {
+      const programId = 1;
+      const activityId = 0;
 
       appAgent
         .put(`/activityStatus/${programId}/${activityId}`)

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -67,6 +67,12 @@ describe('programsRouter', () => {
     });
   });
 
+  describe('GET /activityStatus/:programId', () => {
+    it('should return a list of activities and their completed statuses', done => {
+      // TODO once this function is written.
+    });
+  });
+
   describe('GET /activityStatus/:programId/:activityId', () => {
     it('should respond with a program activity completion status', done => {
       // referencing reflectionsRouter GET test L19
@@ -76,7 +82,7 @@ describe('programsRouter', () => {
       const participantActivity = { id: 1, completed: false };
 
       mockPrincipalId(principalId);
-      mockGetParticipantActivityId.mockResolvedValue({ id: 1}); // how to access participantAvtivity.id from const on L76
+      mockGetParticipantActivityId.mockResolvedValue({ id: 1}); // how to access participantActivity.id from const on L76
       mockGetParticipantActivityCompletion.mockResolvedValue({ status: false }); // how to better set this up
       appAgent
         .get(`/activityStatus/${programId}/${activityId}`)
@@ -87,18 +93,21 @@ describe('programsRouter', () => {
     });
 
     it('should respond with an internal server error if an error was thrown when trying to find a participant activity', done => {
-      // get clarity on the case in which this would happen - what would prompt the service's getParticipantActivityId function to return null?
+      // q: get clarity on the case in which this would happen - what would prompt the service's getParticipantActivityId function to return null?
+      // a: your intuition (as always) here is right. I wouldn't worry too much about testing this unless it's required.
+      // a: but to directly answer your question, getParticipantActivityId should return null if the row isn't found in the table.
       const programId = 1;
       const erroneousActivityId = 2;
       
       mockGetParticipantActivityId.mockResolvedValue(null);
       mockGetParticipantActivityCompletion.mockRejectedValue(new Error());
       appAgent.get(`/activityStatus/${programId}/${erroneousActivityId}`).expect(500, done);
-      // shouldn't this return the NotFoundError message on programsRouter L45? how to test that?
+      // q: shouldn't this return the NotFoundError message on programsRouter L45? how to test that?
+      // a: a NotFoundError message should return HTTP status 404. see line 35 from the questionnairesRouter test for example here.
     });
   });
 
-  describe('POST /activityStatus/:programId/:activityId', () => {
+  describe('PUT /activityStatus/:programId/:activityId', () => {
     it('should respond with a program activity completion status', done => {
       // see competenciesRouter test L119 for PUT/setter function test example
     });

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -154,11 +154,12 @@ describe('programsRouter', () => {
         .send({
           completed: true,
         })
-        .expect(200, err => {
+        .expect(201, err => {
           expect(mockSetParticipantActivityCompletion).toHaveBeenCalledWith(
             principalId,
             programId,
-            activityId
+            activityId,
+            true
           );
           done(err);
         });

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -94,24 +94,22 @@ describe('programsRouter', () => {
         completed: participantActivity.completed,
       });
 
-      appAgent
-        .get(`/activityStatus/${programId}/${activityId}`)
-        .expect(
-          200,
-          itemEnvelope({
-            programId: programId,
-            activityId: activityId,
-            completed: participantActivity.completed,
-          }),
-          err => {
-            expect(mockGetParticipantActivityCompletion).toHaveBeenCalledWith(
-              principalId,
-              programId,
-              activityId
-            );
-            done(err);
-          }
-        );
+      appAgent.get(`/activityStatus/${programId}/${activityId}`).expect(
+        200,
+        itemEnvelope({
+          programId: programId,
+          activityId: activityId,
+          completed: participantActivity.completed,
+        }),
+        err => {
+          expect(mockGetParticipantActivityCompletion).toHaveBeenCalledWith(
+            principalId,
+            programId,
+            activityId
+          );
+          done(err);
+        }
+      );
     });
 
     it('should respond with a bad request error if given an invalid program id', done => {
@@ -121,7 +119,7 @@ describe('programsRouter', () => {
       appAgent
         .get(`/activityStatus/${programId}/${activityId}`)
         .expect(400, done);
-        // should this include a check for the error message content? programsRouter L36
+      // should this include a check for the error message content? programsRouter L36
     });
 
     it('should respond with a bad request error if given an invalid activity id', done => {
@@ -131,7 +129,7 @@ describe('programsRouter', () => {
       appAgent
         .get(`/activityStatus/${programId}/${activityId}`)
         .expect(400, done);
-        // should this include a check for the error message content? programsRouter L36
+      // should this include a check for the error message content? programsRouter L36
     });
 
     it('should respond with an internal server error if an error was thrown while getting participant activity completion status', done => {
@@ -185,7 +183,7 @@ describe('programsRouter', () => {
           completed: true,
         })
         .expect(400, done);
-        // should this include a check for the error message content? programsRouter L79
+      // should this include a check for the error message content? programsRouter L79
     });
 
     it('should respond with a bad request error if given an invalid activity id', done => {
@@ -198,7 +196,7 @@ describe('programsRouter', () => {
           completed: true,
         })
         .expect(400, done);
-        // should this include a check for the error message content? programsRouter L79
+      // should this include a check for the error message content? programsRouter L79
     });
 
     it('should respond with an internal server error if an error was thrown while setting participant activity completion status', done => {

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -145,9 +145,20 @@ describe('programsRouter', () => {
           done(err);
         });
     });
+
+    it('should respond with a bad request error if given an invalid program id', done => {
+      const programId = 0;
+      const activityId = 1;
+
+      appAgent
+        .put(`/activityStatus/${programId}/${activityId}`)
+        .send({
+          completed: true,
+        })
+        .expect(400, done);
+    });
   });
 
-  // test handling program id and activity id that aren't integers
 
   // test that try catch block encounters an error
 });

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -82,12 +82,11 @@ describe('programsRouter', () => {
       const participantActivity = { id: 1, completed: false };
 
       mockPrincipalId(principalId);
-      mockGetParticipantActivityId.mockResolvedValue({ id: 1 }); // how to access participantActivity.id from const on L76
-      mockGetParticipantActivityCompletion.mockResolvedValue({ status: false }); // how to better set this up
+      mockGetParticipantActivityId.mockResolvedValue({ id: participantActivity.id });
+      mockGetParticipantActivityCompletion.mockResolvedValue({ status: participantActivity.completed }); // this error will go away after updates to service file return value
       appAgent
         .get(`/activityStatus/${programId}/${activityId}`)
         .expect(200, itemEnvelope({ status: false }), err => {
-          // again, figure out how to write this better
           expect(mockGetParticipantActivityCompletion).toHaveBeenCalledWith(
             principalId,
             programId,
@@ -97,22 +96,6 @@ describe('programsRouter', () => {
         });
     });
 
-    it('should respond with an internal server error if an error was thrown when trying to find a participant activity', done => {
-      // q: get clarity on the case in which this would happen - what would prompt the service's getParticipantActivityId function to return null?
-      // a: your intuition (as always) here is right. I wouldn't worry too much about testing this unless it's required.
-      // a: but to directly answer your question, getParticipantActivityId should return null if the row isn't found in the table.
-      const programId = 1;
-      const erroneousActivityId = 2;
-
-      mockGetParticipantActivityId.mockResolvedValue(null);
-      mockGetParticipantActivityCompletion.mockRejectedValue(new Error());
-      appAgent
-        .get(`/activityStatus/${programId}/${erroneousActivityId}`)
-        .expect(500, done);
-      // q: shouldn't this return the NotFoundError message on programsRouter L45? how to test that?
-      // a: a NotFoundError message should return HTTP status 404. see line 35 from the questionnairesRouter test for example here.
-    });
-
     // test handling program id and activity id that aren't integers
   });
 
@@ -120,13 +103,6 @@ describe('programsRouter', () => {
     it('should respond with a program activity completion status', done => {
       // see competenciesRouter test L119 for PUT/setter function test example
     });
-
-    it('should respond with a validation error if the completion value in the request body is not a boolean', done => {});
-
-    it('should respond with a validation error if completion value is not provided in the request body', done => {});
-
-    it('should respond with an internal server error if an error was thrown when trying to find a participant activity', done => {});
-  });
 
     // test handling program id and activity id that aren't integers
 });

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -79,23 +79,19 @@ describe('programsRouter', () => {
 
   describe('GET /activityStatus/:programId/:activityId', () => {
     it('should respond with a program activity completion status', done => {
-      // referencing reflectionsRouter GET test L19
       const principalId = 1;
       const programId = 1;
       const activityId = 1;
       const participantActivity = { id: 1, completed: false };
 
       mockPrincipalId(principalId);
-      mockGetParticipantActivityId.mockResolvedValue({
-        id: participantActivity.id,
-      });
       mockGetParticipantActivityCompletion.mockResolvedValue({
-        status: participantActivity.completed,
-      }); // this error will go away after updates to service file return value
+        completed: participantActivity.completed,
+      });
+      
       appAgent
         .get(`/activityStatus/${programId}/${activityId}`)
-        .expect(200, itemEnvelope({ status: false }), err => {
-          // should there be an expectation here for getParticipantActivityId to have been called as well?
+        .expect(200, itemEnvelope({ programId: programId, activityId: activityId, completed: participantActivity.completed }), err => {
           expect(mockGetParticipantActivityCompletion).toHaveBeenCalledWith(
             principalId,
             programId,
@@ -110,27 +106,23 @@ describe('programsRouter', () => {
 
   describe('PUT /activityStatus/:programId/:activityId', () => {
     it('should respond with a program activity completion status', done => {
-      // see competenciesRouter test L119 for PUT/setter function test example
       const principalId = 1;
       const programId = 1;
       const activityId = 1;
       const participantActivity = { id: 1, completed: false };
 
       mockPrincipalId(principalId);
-      mockGetParticipantActivityId.mockResolvedValue({
-        id: participantActivity.id,
-      });
       mockSetParticipantActivityCompletion.mockResolvedValue({
-        id: 1,
+        participantActivityId: 1,
         completed: true,
       });
+
       appAgent
         .put(`/activityStatus/${programId}/${activityId}`)
         .send({
           completed: true,
         })
         .expect(200, err => {
-          // should there be an expectation here for getParticipantActivityId to have been called as well?
           expect(mockSetParticipantActivityCompletion).toHaveBeenCalledWith(
             principalId,
             programId,

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -64,4 +64,32 @@ describe('programsRouter', () => {
       });
     });
   });
+
+  describe('GET /activityStatus/:programId/:activityId', () => {
+    it('should respond with a program activity completion status', done => {
+      
+    });
+
+    it('should respond with an internal server error if an error was thrown when trying to find a participant activity', done => {
+
+    });
+  });
+
+  describe('POST /activityStatus/:programId/:activityId', () => {
+    it('should respond with a program activity completion status', done => {
+      // see competenciesRouter test L119 for PUT/setter function test example
+    });
+
+    it('should respond with a validation error if the completion value in the request body is not a boolean', done => {
+
+    });
+
+    it('should respond with a validation error if completion value is not provided in the request body', done => {
+
+    });
+
+    it('should respond with an internal server error if an error was thrown when trying to find a participant activity', done => {
+
+    });
+  });
 });

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -101,7 +101,14 @@ describe('programsRouter', () => {
         });
     });
 
-    // test handling program id and activity id that aren't integers
+    it('should respond with a bad request error if given an invalid program id', done => {
+      const programId = 0;
+      const activityId = 1;
+      
+      appAgent
+        .get(`/activityStatus/${programId}/${activityId}`)
+        .expect(400, done);
+    });
 
     // test that try catch block encounters an error
   });

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -93,29 +93,37 @@ describe('programsRouter', () => {
       mockGetParticipantActivityCompletion.mockResolvedValue({
         completed: participantActivity.completed,
       });
-      
+
       appAgent
         .get(`/activityStatus/${programId}/${activityId}`)
-        .expect(200, itemEnvelope({ programId: programId, activityId: activityId, completed: participantActivity.completed }), err => {
-          expect(mockGetParticipantActivityCompletion).toHaveBeenCalledWith(
-            principalId,
-            programId,
-            activityId
-          );
-          done(err);
-        });
+        .expect(
+          200,
+          itemEnvelope({
+            programId: programId,
+            activityId: activityId,
+            completed: participantActivity.completed,
+          }),
+          err => {
+            expect(mockGetParticipantActivityCompletion).toHaveBeenCalledWith(
+              principalId,
+              programId,
+              activityId
+            );
+            done(err);
+          }
+        );
     });
 
     it('should respond with a bad request error if given an invalid program id', done => {
       const programId = 0;
       const activityId = 1;
-      
+
       appAgent
         .get(`/activityStatus/${programId}/${activityId}`)
         .expect(400, done);
     });
 
-    // test that try catch block encounters an error
+    it('should respond with an internal server error if an error was thrown while getting participant activity completion status', done => {});
   });
 
   describe('PUT /activityStatus/:programId/:activityId', () => {
@@ -157,8 +165,7 @@ describe('programsRouter', () => {
         })
         .expect(400, done);
     });
+
+    it('should respond with an internal server error if an error was thrown while setting participant activity completion status', done => {});
   });
-
-
-  // test that try catch block encounters an error
 });

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -112,6 +112,8 @@ describe('programsRouter', () => {
       // q: shouldn't this return the NotFoundError message on programsRouter L45? how to test that?
       // a: a NotFoundError message should return HTTP status 404. see line 35 from the questionnairesRouter test for example here.
     });
+
+    // test handling program id and activity id that aren't integers
   });
 
   describe('PUT /activityStatus/:programId/:activityId', () => {
@@ -125,4 +127,6 @@ describe('programsRouter', () => {
 
     it('should respond with an internal server error if an error was thrown when trying to find a participant activity', done => {});
   });
+
+    // test handling program id and activity id that aren't integers
 });

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -1,5 +1,9 @@
 import { collectionEnvelope, itemEnvelope } from '../responseEnvelope';
-import { listProgramsWithActivities, getParticipantActivityId, getParticipantActivityCompletion } from '../../services/programsService';
+import {
+  listProgramsWithActivities,
+  getParticipantActivityId,
+  getParticipantActivityCompletion,
+} from '../../services/programsService';
 import { createAppAgentForRouter, mockPrincipalId } from '../routerTestUtils';
 import programsRouter from '../programsRouter';
 import { ProgramWithActivities } from '../../models';
@@ -7,7 +11,9 @@ import { ProgramWithActivities } from '../../models';
 jest.mock('../../services/programsService');
 const mockListProgramsWithActivities = jest.mocked(listProgramsWithActivities);
 const mockGetParticipantActivityId = jest.mocked(getParticipantActivityId);
-const mockGetParticipantActivityCompletion = jest.mocked(getParticipantActivityCompletion);
+const mockGetParticipantActivityCompletion = jest.mocked(
+  getParticipantActivityCompletion
+);
 
 describe('programsRouter', () => {
   const appAgent = createAppAgentForRouter(programsRouter);
@@ -76,12 +82,17 @@ describe('programsRouter', () => {
       const participantActivity = { id: 1, completed: false };
 
       mockPrincipalId(principalId);
-      mockGetParticipantActivityId.mockResolvedValue({ id: 1}); // how to access participantActivity.id from const on L76
+      mockGetParticipantActivityId.mockResolvedValue({ id: 1 }); // how to access participantActivity.id from const on L76
       mockGetParticipantActivityCompletion.mockResolvedValue({ status: false }); // how to better set this up
       appAgent
         .get(`/activityStatus/${programId}/${activityId}`)
-        .expect(200, itemEnvelope({ status: false }), err => { // again, figure out how to write this better
-          expect(mockGetParticipantActivityCompletion).toHaveBeenCalledWith(principalId, programId, activityId);
+        .expect(200, itemEnvelope({ status: false }), err => {
+          // again, figure out how to write this better
+          expect(mockGetParticipantActivityCompletion).toHaveBeenCalledWith(
+            principalId,
+            programId,
+            activityId
+          );
           done(err);
         });
     });
@@ -92,10 +103,12 @@ describe('programsRouter', () => {
       // a: but to directly answer your question, getParticipantActivityId should return null if the row isn't found in the table.
       const programId = 1;
       const erroneousActivityId = 2;
-      
+
       mockGetParticipantActivityId.mockResolvedValue(null);
       mockGetParticipantActivityCompletion.mockRejectedValue(new Error());
-      appAgent.get(`/activityStatus/${programId}/${erroneousActivityId}`).expect(500, done);
+      appAgent
+        .get(`/activityStatus/${programId}/${erroneousActivityId}`)
+        .expect(500, done);
       // q: shouldn't this return the NotFoundError message on programsRouter L45? how to test that?
       // a: a NotFoundError message should return HTTP status 404. see line 35 from the questionnairesRouter test for example here.
     });
@@ -106,16 +119,10 @@ describe('programsRouter', () => {
       // see competenciesRouter test L119 for PUT/setter function test example
     });
 
-    it('should respond with a validation error if the completion value in the request body is not a boolean', done => {
+    it('should respond with a validation error if the completion value in the request body is not a boolean', done => {});
 
-    });
+    it('should respond with a validation error if completion value is not provided in the request body', done => {});
 
-    it('should respond with a validation error if completion value is not provided in the request body', done => {
-
-    });
-
-    it('should respond with an internal server error if an error was thrown when trying to find a participant activity', done => {
-
-    });
+    it('should respond with an internal server error if an error was thrown when trying to find a participant activity', done => {});
   });
 });

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -127,7 +127,7 @@ describe('programsRouter', () => {
       appAgent
         .put(`/activityStatus/${programId}/${activityId}`)
         .send({
-          "completed": true,
+          completed: true,
         })
         .expect(200, err => {
           // should there be an expectation here for getParticipantActivityId to have been called as well?

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -67,12 +67,6 @@ describe('programsRouter', () => {
     });
   });
 
-  describe('GET /activityStatus/:programId', () => {
-    it('should return a list of activities and their completed statuses', done => {
-      // TODO once this function is written.
-    });
-  });
-
   describe('GET /activityStatus/:programId/:activityId', () => {
     it('should respond with a program activity completion status', done => {
       // referencing reflectionsRouter GET test L19

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -82,8 +82,12 @@ describe('programsRouter', () => {
       const participantActivity = { id: 1, completed: false };
 
       mockPrincipalId(principalId);
-      mockGetParticipantActivityId.mockResolvedValue({ id: participantActivity.id });
-      mockGetParticipantActivityCompletion.mockResolvedValue({ status: participantActivity.completed }); // this error will go away after updates to service file return value
+      mockGetParticipantActivityId.mockResolvedValue({
+        id: participantActivity.id,
+      });
+      mockGetParticipantActivityCompletion.mockResolvedValue({
+        status: participantActivity.completed,
+      }); // this error will go away after updates to service file return value
       appAgent
         .get(`/activityStatus/${programId}/${activityId}`)
         .expect(200, itemEnvelope({ status: false }), err => {
@@ -103,6 +107,7 @@ describe('programsRouter', () => {
     it('should respond with a program activity completion status', done => {
       // see competenciesRouter test L119 for PUT/setter function test example
     });
+  });
 
-    // test handling program id and activity id that aren't integers
+  // test handling program id and activity id that aren't integers
 });

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -121,9 +121,19 @@ describe('programsRouter', () => {
       appAgent
         .get(`/activityStatus/${programId}/${activityId}`)
         .expect(400, done);
+        // should this include a check for the error message content? programsRouter L36
     });
 
-    it('should respond with an internal server error if an error was thrown while getting participant activity completion status', done => {});
+    it('should respond with an internal server error if an error was thrown while getting participant activity completion status', done => {
+      const programId = 1;
+      const activityId = 1;
+
+      mockGetParticipantActivityCompletion.mockRejectedValue(new Error());
+
+      appAgent
+        .get(`/activityStatus/${programId}/${activityId}`)
+        .expect(500, done);
+    });
   });
 
   describe('PUT /activityStatus/:programId/:activityId', () => {
@@ -164,8 +174,19 @@ describe('programsRouter', () => {
           completed: true,
         })
         .expect(400, done);
+        // should this include a check for the error message content? programsRouter L79
     });
 
-    it('should respond with an internal server error if an error was thrown while setting participant activity completion status', done => {});
+    it('should respond with an internal server error if an error was thrown while setting participant activity completion status', done => {
+      const programId = 1;
+      const activityId = 1;
+
+      mockSetParticipantActivityCompletion.mockRejectedValue(new Error());
+
+      appAgent
+        .put(`/activityStatus/${programId}/${activityId}`)
+        .send({ completed: true })
+        .expect(500, done);
+    });
   });
 });

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -102,6 +102,8 @@ describe('programsRouter', () => {
     });
 
     // test handling program id and activity id that aren't integers
+
+    // test that try catch block encounters an error
   });
 
   describe('PUT /activityStatus/:programId/:activityId', () => {
@@ -134,4 +136,6 @@ describe('programsRouter', () => {
   });
 
   // test handling program id and activity id that aren't integers
+
+  // test that try catch block encounters an error
 });

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -1,7 +1,6 @@
 import { collectionEnvelope, itemEnvelope } from '../responseEnvelope';
 import {
   listProgramsWithActivities,
-  getParticipantActivityId,
   getParticipantActivityCompletion,
   setParticipantActivityCompletion,
 } from '../../services/programsService';
@@ -11,7 +10,6 @@ import { ProgramWithActivities } from '../../models';
 
 jest.mock('../../services/programsService');
 const mockListProgramsWithActivities = jest.mocked(listProgramsWithActivities);
-const mockGetParticipantActivityId = jest.mocked(getParticipantActivityId);
 const mockGetParticipantActivityCompletion = jest.mocked(
   getParticipantActivityCompletion
 );
@@ -149,13 +147,15 @@ describe('programsRouter', () => {
       const principalId = 1;
       const programId = 1;
       const activityId = 1;
-      const participantActivity = { id: 1, completed: false };
-
-      mockPrincipalId(principalId);
-      mockSetParticipantActivityCompletion.mockResolvedValue({
+      const participantActivity = {
         participantActivityId: 1,
         completed: true,
-      });
+      };
+
+      mockPrincipalId(principalId);
+      mockSetParticipantActivityCompletion.mockResolvedValue(
+        participantActivity
+      );
 
       appAgent
         .put(`/activityStatus/${programId}/${activityId}`)

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -34,8 +34,8 @@ programsRouter.get(
         programIdNum,
         activityIdNum
       );
-    } catch (err) {
-      next(err);
+    } catch (error) {
+      next(error);
       return;
     }
     if (!activityCompletionStatus) {

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 
 import { collectionEnvelope, itemEnvelope } from './responseEnvelope';
-import { NotFoundError, ValidationError } from './httpErrors';
+import { BadRequestError, NotFoundError, ValidationError } from './httpErrors';
 import {
   listProgramsWithActivities,
   getParticipantActivityCompletion,
@@ -23,10 +23,18 @@ programsRouter.get(
     const { programId, activityId } = req.params;
     const { principalId } = req.session;
 
-    // q: should these be moved into the try/catch statement so that an error is thrown if the id params cant be translated into a num?
-    // a: Good thinking! Check out line 12 in questionnairesRouter for an example of how to handle this without try/catch.
     const programIdNum = Number(programId);
     const activityIdNum = Number(activityId);
+
+    if(!Number.isInteger(programIdNum) || programIdNum < 1) {
+      next(new BadRequestError(`"${programIdNum}" is not a valid program id.`));
+      return;
+    }
+
+    if(!Number.isInteger(activityIdNum) || activityIdNum < 1) {
+      next(new BadRequestError(`"${activityId}" is not a valid activity id.`));
+      return;
+    }
 
     let activityCompletionStatus;
 
@@ -36,12 +44,14 @@ programsRouter.get(
         programIdNum,
         activityIdNum
       );
+      // return value should look like: { participantActivityId: x, completedStatus: boolean}
+      // if a participantActivityId does not exist: value is null or object/hash is empty?
     } catch (error) {
       next(error);
       return;
     }
-    // TODO: activityCompletionStatus should always be true/false, since we've decided not to do any error checking on the backend
-    if (!activityCompletionStatus) {
+
+    if (!activityCompletionStatus) { // value will be empty if service function doesn't successfully locate a participant activity
       next(
         new NotFoundError(
           `A participant activity with the activity id "${activityIdNum}" could not be found.`
@@ -67,18 +77,20 @@ programsRouter.put(
     // request body shoud look like: {"completed": true}
     const { principalId } = req.session;
 
-    // TODO: see comment from line 31 above
     const programIdNum = Number(programId);
     const activityIdNum = Number(activityId);
 
-    let updatedCompletionStatus;
-
-    // q: will this also address a case in which a completed value is not included in the request body?
-    // a: if the body doesn't contain a key called "completed", then the value of completed will be null
-    if (typeof completed !== 'boolean') {
-      next(new ValidationError('`completed` must be a boolean'));
+    if (!Number.isInteger(programIdNum) || programIdNum < 1) {
+      next(new BadRequestError(`"${programIdNum}" is not a valid program id.`));
       return;
     }
+
+    if (!Number.isInteger(activityIdNum) || activityIdNum < 1) {
+      next(new BadRequestError(`"${activityId}" is not a valid activity id.`));
+      return;
+    }
+
+    let updatedCompletionStatus;
 
     try {
       updatedCompletionStatus = await setParticipantActivityCompletion(
@@ -87,10 +99,6 @@ programsRouter.put(
         activityIdNum,
         completed
       );
-
-      // TODO: this function should return the row ID if successful. send back an error if it isn't.
-      if (typeof updatedCompletionStatus !== 'number') {
-      }
     } catch (error) {
       next(error);
       return;

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -46,7 +46,7 @@ programsRouter.get(
       )
     };
 
-    res.json(itemEnvelope({ status: activityCompletionStatus }));
+    res.json(itemEnvelope(activityCompletionStatus));
   }
 );
 

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -12,4 +12,28 @@ programsRouter.get('/', async (req, res) => {
   );
 });
 
+programsRouter.get('/activityStatus/:programId/:activityId', async (req, res, next) => {
+// look into what `next` param is for and identify whether necessary here (it's present in almost all other router functions except the GET Programs function right above here)
+// is it possible to define programId and activityId on one line?: const { programId, activityId } = req.params
+const { programId } = req.params;
+const { activityId } = req.params;
+const { principalId } = req.session;
+
+let participantActivityId;
+let activityCompletionStatus; // alternative variable names: isCompleted; completionStatus
+
+// participantActivityId = getParticipantActivityId(principalId, programId, activityId)
+  // value will look like: `{ id: participantActivityId }`
+
+// checks:
+  // program exists
+  // activity exists
+  // curriculumId of program matches curriculumId of activity
+  // there's a ParticipantActivities record associated with the specified principalId, programId, and activityId
+
+// activityCompletionStatus = getCompletionStatus(participantActivityId)
+// wrap activityCompletionStatus in itemEnvelope: res.json(itemEnvelope({ activityCompletionStatus: <boolean value> }));
+  // thinking this^ should be a key/value pair so that webapp can reference the value by the key?
+});
+
 export default programsRouter;

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -22,7 +22,8 @@ programsRouter.get(
   async (req, res, next) => {
     const { programId, activityId } = req.params;
     const { principalId } = req.session;
-
+    
+    // should these be moved into the try/catch statement so that an error is thrown if the id params cant be translated into a num?
     const programIdNum = Number(programId);
     const activityIdNum = Number(activityId);
 
@@ -63,6 +64,7 @@ programsRouter.post(
 
     let updatedCompletionStatus;
 
+    // will this also address a case in which a completed value is not included in the request body?
     if (typeof completed !== 'boolean') {
       next(new ValidationError('`completion` must be a boolean'));
       return;

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -97,7 +97,4 @@ programsRouter.put(
   }
 );
 
-// future issue: grabbing participant activities upon render in order to enable color coding of event types in program calendar view
-// specifically re: color coding completed assignment activities
-
 export default programsRouter;

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 
 import { collectionEnvelope, itemEnvelope } from './responseEnvelope';
-import { BadRequestError, NotFoundError, ValidationError } from './httpErrors';
+import { BadRequestError } from './httpErrors';
 import {
   listProgramsWithActivities,
   getParticipantActivityCompletion,

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -1,7 +1,10 @@
 import { Router } from 'express';
 
 import { collectionEnvelope, itemEnvelope } from './responseEnvelope';
-import { listProgramsWithActivities, getParticipantActivityCompletion } from '../services/programsService'; // add participantActivity functions
+import {
+  listProgramsWithActivities,
+  getParticipantActivityCompletion,
+} from '../services/programsService'; // add participantActivity functions
 
 const programsRouter = Router();
 
@@ -12,27 +15,34 @@ programsRouter.get('/', async (req, res) => {
   );
 });
 
-programsRouter.get('/activityStatus/:programId/:activityId', async (req, res, next) => {
-  const { programId, activityId } = req.params;
-  const { principalId } = req.session;
+programsRouter.get(
+  '/activityStatus/:programId/:activityId',
+  async (req, res, next) => {
+    const { programId, activityId } = req.params;
+    const { principalId } = req.session;
 
-  let participantActivityId;
-  let activityCompletionStatus; // alternative variable names: isCompleted; completionStatus
+    let participantActivityId;
+    let activityCompletionStatus; // alternative variable names: isCompleted; completionStatus
 
- // checks:
-  // program exists
-  // activity exists
-  // curriculumId of program matches curriculumId of activity
-  // there's a ParticipantActivities record associated with the specified principalId, programId, and activityId
-  
-  try {
-    activityCompletionStatus = await getParticipantActivityCompletion(principalId, Number(programId), Number(activityId))
-  } catch (err) {
-    next(err);
-    return;
+    // checks:
+    // program exists
+    // activity exists
+    // curriculumId of program matches curriculumId of activity
+    // there's a ParticipantActivities record associated with the specified principalId, programId, and activityId
+
+    try {
+      activityCompletionStatus = await getParticipantActivityCompletion(
+        principalId,
+        Number(programId),
+        Number(activityId)
+      );
+    } catch (err) {
+      next(err);
+      return;
+    }
+
+    res.json(itemEnvelope({ status: activityCompletionStatus }));
   }
-
-  res.json(itemEnvelope({ status: activityCompletionStatus }));
-});
+);
 
 export default programsRouter;

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -44,27 +44,16 @@ programsRouter.get(
         programIdNum,
         activityIdNum
       );
-      // return value should look like: { participantActivityId: x, completedStatus: boolean}
-      // if a participantActivityId does not exist: value is null or object/hash is empty?
     } catch (error) {
       next(error);
       return;
-    }
-
-    if (!activityCompletionStatus) {
-      // value will be empty if service function doesn't successfully locate a participant activity
-      next(
-        new NotFoundError(
-          `A participant activity with the activity id "${activityIdNum}" could not be found.`
-        )
-      );
     }
 
     res.json(
       itemEnvelope({
         programId: programIdNum,
         activityId: activityIdNum,
-        completed: activityCompletionStatus,
+        completed: activityCompletionStatus.completed,
       })
     );
   }
@@ -75,7 +64,6 @@ programsRouter.put(
   async (req, res, next) => {
     const { programId, activityId } = req.params;
     const { completed } = req.body;
-    // request body shoud look like: {"completed": true}
     const { principalId } = req.session;
 
     const programIdNum = Number(programId);
@@ -91,10 +79,10 @@ programsRouter.put(
       return;
     }
 
-    let updatedCompletionStatus;
+    let updatedParticipantActivity;
 
     try {
-      updatedCompletionStatus = await setParticipantActivityCompletion(
+      updatedParticipantActivity = await setParticipantActivityCompletion(
         principalId,
         programIdNum,
         activityIdNum,
@@ -105,7 +93,7 @@ programsRouter.put(
       return;
     }
 
-    res.status(201).json(itemEnvelope(updatedCompletionStatus));
+    res.status(201).json(itemEnvelope(updatedParticipantActivity));
   }
 );
 

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -17,10 +17,6 @@ programsRouter.get('/', async (req, res) => {
   );
 });
 
-// TODO: get a list of "assignment" activities and their statuses for this user
-// The response should look like collectionEnvelope([{programId: ,activityId: ,completed: }, ...]
-programsRouter.get('/activityStatus/:programId', async (req, res, next) => {});
-
 programsRouter.get(
   '/activityStatus/:programId/:activityId',
   async (req, res, next) => {

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -19,6 +19,12 @@ programsRouter.get('/activityStatus/:programId/:activityId', async (req, res, ne
   let participantActivityId;
   let activityCompletionStatus; // alternative variable names: isCompleted; completionStatus
 
+ // checks:
+  // program exists
+  // activity exists
+  // curriculumId of program matches curriculumId of activity
+  // there's a ParticipantActivities record associated with the specified principalId, programId, and activityId
+  
   try {
     activityCompletionStatus = await getParticipantActivityCompletion(principalId, Number(programId), Number(activityId))
   } catch (err) {

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -26,12 +26,12 @@ programsRouter.get(
     const programIdNum = Number(programId);
     const activityIdNum = Number(activityId);
 
-    if(!Number.isInteger(programIdNum) || programIdNum < 1) {
+    if (!Number.isInteger(programIdNum) || programIdNum < 1) {
       next(new BadRequestError(`"${programIdNum}" is not a valid program id.`));
       return;
     }
 
-    if(!Number.isInteger(activityIdNum) || activityIdNum < 1) {
+    if (!Number.isInteger(activityIdNum) || activityIdNum < 1) {
       next(new BadRequestError(`"${activityId}" is not a valid activity id.`));
       return;
     }
@@ -51,7 +51,8 @@ programsRouter.get(
       return;
     }
 
-    if (!activityCompletionStatus) { // value will be empty if service function doesn't successfully locate a participant activity
+    if (!activityCompletionStatus) {
+      // value will be empty if service function doesn't successfully locate a participant activity
       next(
         new NotFoundError(
           `A participant activity with the activity id "${activityIdNum}" could not be found.`

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -1,6 +1,5 @@
 import { Router } from 'express';
 
-
 import { collectionEnvelope, itemEnvelope } from './responseEnvelope';
 import { NotFoundError } from './httpErrors';
 import {
@@ -44,34 +43,42 @@ programsRouter.get(
         new NotFoundError(
           `A participant activity with the activity id "${activityIdNum}" could not be found.`
         )
-      )
-    };
+      );
+    }
 
     res.json(itemEnvelope(activityCompletionStatus));
   }
 );
 
-programsRouter.post('/activityStatus/:programId/:activityId', async (req, res, next) => {
-  const { programId, activityId } = req.params;
-  const { completed } = req.body;
-  const { principalId } = req.session;
+programsRouter.post(
+  '/activityStatus/:programId/:activityId',
+  async (req, res, next) => {
+    const { programId, activityId } = req.params;
+    const { completed } = req.body;
+    const { principalId } = req.session;
 
-  const programIdNum = Number(programId);
-  const activityIdNum = Number(activityId);
+    const programIdNum = Number(programId);
+    const activityIdNum = Number(activityId);
 
-  let updatedCompletionStatus;
+    let updatedCompletionStatus;
 
-  try {
-    updatedCompletionStatus = await setParticipantActivityCompletion(principalId, programIdNum, activityIdNum, completed);
-  } catch (error) {
-    next(error);
-    return;
+    try {
+      updatedCompletionStatus = await setParticipantActivityCompletion(
+        principalId,
+        programIdNum,
+        activityIdNum,
+        completed
+      );
+    } catch (error) {
+      next(error);
+      return;
+    }
+
+    res.status(201).json(itemEnvelope(updatedCompletionStatus));
   }
-
-  res.status(201).json(itemEnvelope(updatedCompletionStatus));
-});
+);
 
 // future issue: grabbing participant activities upon render in order to enable color coding of event types in program calendar view
-  // specifically re: color coding completed assignment activities
+// specifically re: color coding completed assignment activities
 
 export default programsRouter;

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -22,7 +22,7 @@ programsRouter.get(
   async (req, res, next) => {
     const { programId, activityId } = req.params;
     const { principalId } = req.session;
-    
+
     // q: should these be moved into the try/catch statement so that an error is thrown if the id params cant be translated into a num?
     // a: Good thinking! Check out line 12 in questionnairesRouter for an example of how to handle this without try/catch.
     const programIdNum = Number(programId);
@@ -49,11 +49,13 @@ programsRouter.get(
       );
     }
 
-    res.json(itemEnvelope({
-      programId: programIdNum,
-      activityId: activityIdNum,
-      completed: activityCompletionStatus
-    }));
+    res.json(
+      itemEnvelope({
+        programId: programIdNum,
+        activityId: activityIdNum,
+        completed: activityCompletionStatus,
+      })
+    );
   }
 );
 
@@ -87,7 +89,8 @@ programsRouter.put(
       );
 
       // TODO: this function should return the row ID if successful. send back an error if it isn't.
-      if (typeof updatedCompletionStatus !== 'number') {}
+      if (typeof updatedCompletionStatus !== 'number') {
+      }
     } catch (error) {
       next(error);
       return;

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 
 import { collectionEnvelope, itemEnvelope } from './responseEnvelope';
-import { NotFoundError } from './httpErrors';
+import { NotFoundError, ValidationError } from './httpErrors';
 import {
   listProgramsWithActivities,
   getParticipantActivityCompletion,
@@ -61,6 +61,11 @@ programsRouter.post(
     const activityIdNum = Number(activityId);
 
     let updatedCompletionStatus;
+
+    if (typeof completed !== 'boolean') {
+      next(new ValidationError('`completion` must be a boolean'));
+      return;
+    }
 
     try {
       updatedCompletionStatus = await setParticipantActivityCompletion(

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -6,6 +6,7 @@ import { NotFoundError } from './httpErrors';
 import {
   listProgramsWithActivities,
   getParticipantActivityCompletion,
+  setParticipantActivityCompletion,
 } from '../services/programsService';
 
 const programsRouter = Router();
@@ -49,6 +50,26 @@ programsRouter.get(
     res.json(itemEnvelope(activityCompletionStatus));
   }
 );
+
+programsRouter.post('/activityStatus/:programId/:activityId', async (req, res, next) => {
+  const { programId, activityId } = req.params;
+  const { completed } = req.body;
+  const { principalId } = req.session;
+
+  const programIdNum = Number(programId);
+  const activityIdNum = Number(activityId);
+
+  let updatedCompletionStatus;
+
+  try {
+    updatedCompletionStatus = await setParticipantActivityCompletion(principalId, programIdNum, activityIdNum, completed);
+  } catch (error) {
+    next(error);
+    return;
+  }
+
+  res.status(201).json(itemEnvelope(updatedCompletionStatus));
+});
 
 // future issue: grabbing participant activities upon render in order to enable color coding of event types in program calendar view
   // specifically re: color coding completed assignment activities

--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -55,6 +55,7 @@ programsRouter.post(
   async (req, res, next) => {
     const { programId, activityId } = req.params;
     const { completed } = req.body;
+    // request body shoud look like: {"completed": true}
     const { principalId } = req.session;
 
     const programIdNum = Number(programId);


### PR DESCRIPTION
## Proposed changes

This PR resolves #455 by creating getter and setter functions for individual an participantActivity's completion status, as well as tests for these new functions.

Manually tested on local machine:
- GET `http://api.rhi.zone-development/programs/activityStatus/1/1` returned `{"data":{"programId":1,"activityId":1,"completed":false}}`
- POST `http://api.rhi.zone-development/programs/activityStatus/1/1` with request body `{"completed": true}` returned `{"data":{"completed":false}}`


## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number? - a few merges from main are missing this
- [x] Are all code changes sufficiently tested?
