### PR TITLE
#481 Setter service function should return correct values

### DIFF
--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -562,10 +562,12 @@ describe('programsService', () => {
       mockQuery(
         'select `id`, `completed` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
         [principalId, programId, activityId],
-        [{ 
-          id: participantActivitiesList[0].id,
-          completed: false, 
-        }]
+        [
+          {
+            id: participantActivitiesList[0].id,
+            completed: false,
+          },
+        ]
       );
       expect(
         await setParticipantActivityCompletion(
@@ -589,10 +591,12 @@ describe('programsService', () => {
       mockQuery(
         'select `id`, `completed` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
         [principalId, programId, activityId2],
-        [{ 
-          id: newIndex,
-          completed: false, 
-        }]
+        [
+          {
+            id: newIndex,
+            completed: false,
+          },
+        ]
       );
       expect(
         await setParticipantActivityCompletion(

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -557,12 +557,15 @@ describe('programsService', () => {
       mockQuery(
         'insert into `participant_activities` (`activity_id`, `completed`, `principal_id`, `program_id`) values (?, ?, ?, ?) on duplicate key update `completed` = ?',
         [activityId, completed, principalId, programId, completed],
-        [
-          {
-            id: participantActivitiesList[0].id,
-            completed: false,
-          },
-        ]
+        []
+      );
+      mockQuery(
+        'select `id`, `completed` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
+        [principalId, programId, activityId],
+        [{ 
+          id: participantActivitiesList[0].id,
+          completed: false, 
+        }]
       );
       expect(
         await setParticipantActivityCompletion(
@@ -581,12 +584,15 @@ describe('programsService', () => {
       mockQuery(
         'insert into `participant_activities` (`activity_id`, `completed`, `principal_id`, `program_id`) values (?, ?, ?, ?) on duplicate key update `completed` = ?',
         [activityId2, completed, principalId, programId, completed],
-        [
-          {
-            id: newIndex,
-            completed: false,
-          },
-        ]
+        []
+      );
+      mockQuery(
+        'select `id`, `completed` from `participant_activities` where `principal_id` = ? and `program_id` = ? and `activity_id` = ?',
+        [principalId, programId, activityId2],
+        [{ 
+          id: newIndex,
+          completed: false, 
+        }]
       );
       expect(
         await setParticipantActivityCompletion(

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -361,7 +361,7 @@ export const setParticipantActivityCompletion = async (
   activityId: number,
   completed: boolean
 ) => {
-  const [participantActivityRow] = await db('participant_activities')
+  await db('participant_activities')
     .insert({
       principal_id: principalId,
       program_id: programId,
@@ -370,8 +370,17 @@ export const setParticipantActivityCompletion = async (
     })
     .onConflict(['program_id', 'principal_id', 'activity_id'])
     .merge({ completed: completed });
+
+  const [participantActivity] = await db('participant_activities')
+    .select('id', 'completed')
+    .where({
+      principal_id: principalId,
+      program_id: programId,
+      activity_id: activityId,
+    });
+
   return {
-    participantActivityId: participantActivityRow.id,
-    completed: participantActivityRow.completed === 1,
+    participantActivityId: participantActivity.id,
+    completed: participantActivity.completed === 1,
   };
 };


### PR DESCRIPTION
This issue resolves #481 by:
## Proposed changes

`setParticipantActivityCompletion()` return the participantActivityId and the completion status (true or false) of an inserted row in the table
Test functions updated to reflect the above service function changed

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [ ] Are there screenshots for UI changes?
