### PR TITLE
469 api route and service function get all activities

### DIFF
--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -6,6 +6,7 @@ import {
   listProgramsWithActivities,
   getParticipantActivityCompletion,
   setParticipantActivityCompletion,
+  listParticipantActivitiesCompletionForProgram,
 } from '../services/programsService';
 
 const programsRouter = Router();
@@ -21,6 +22,32 @@ programsRouter.get('/', async (req, res, next) => {
   res.json(
     collectionEnvelope(programsWithActivities, programsWithActivities.length)
   );
+});
+
+programsRouter.get('/activityStatus/:programId', async (req, res, next) => {
+  const { programId } = req.params;
+  const { principalId } = req.session;
+
+  const programIdNum = Number(programId);
+
+  if (!Number.isInteger(programIdNum) || programIdNum < 1) {
+    next(new BadRequestError(`"${programIdNum}" is not a valid program id.`));
+    return;
+  }
+
+  let participantActivitiesList;
+
+  try {
+    participantActivitiesList =
+      await listParticipantActivitiesCompletionForProgram(
+        principalId,
+        programIdNum
+      );
+  } catch (error) {
+    next(error);
+    return;
+  }
+  res.json(itemEnvelope(participantActivitiesList));
 });
 
 programsRouter.get(

--- a/api/src/models.d.ts
+++ b/api/src/models.d.ts
@@ -62,3 +62,13 @@ export interface ParticipantActivities {
   principal_id: number;
   completed: boolean;
 }
+
+export interface ParticipantActivitiesWithCompletionStatus {
+  activity_id: number;
+  completed: boolean;
+}
+
+export interface participantAcitivityForProgram {
+  programId: number;
+  participantActivities: ParticipantActivitiesWithCompletionStatus[];
+}

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -12,6 +12,7 @@ import {
   getParticipantActivityId,
   getParticipantActivityCompletion,
   setParticipantActivityCompletion,
+  listParticipantActivitiesCompletionForProgram,
 } from '../programsService';
 import {
   Program,
@@ -20,6 +21,7 @@ import {
   ActivityType,
   ProgramWithActivities,
   ParticipantActivities,
+  participantAcitivityForProgram,
 } from '../../models';
 
 import { mockQuery } from '../mockDb';
@@ -168,6 +170,16 @@ const participantActivitiesList: ParticipantActivities[] = [
     completed: true,
   },
 ];
+
+const participantActivitiesForProgram: participantAcitivityForProgram = {
+  programId: 1,
+  participantActivities: [
+    { activity_id: 7, completed: false },
+    { activity_id: 8, completed: false },
+    { activity_id: 10, completed: true },
+  ],
+};
+
 const programActivitiesList: ProgramActivity[][] = [
   [
     {
@@ -613,13 +625,24 @@ describe('programsService', () => {
   });
 
   describe('listParticipantActivitiesCompletionForProgram', () => {
-    // const programId = 1;
-    // const principalId = 3;
+    const programId = 1;
+    const principalId = 3;
     it('should return a list of participant activities with their completion statuses', async () => {
-      return;
-    });
-    it('should return null if the programId does not exist', async () => {
-      return;
+      mockQuery(
+        'select `activity_id`, `completed` from `participant_activities` where `program_id` = ? and `principal_id` = ?',
+        [programId, principalId],
+        [
+          { activity_id: 7, completed: false },
+          { activity_id: 8, completed: false },
+          { activity_id: 10, completed: true },
+        ]
+      );
+      expect(
+        await listParticipantActivitiesCompletionForProgram(
+          principalId,
+          programId
+        )
+      ).toEqual(participantActivitiesForProgram);
     });
   });
 });

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -611,4 +611,15 @@ describe('programsService', () => {
       });
     });
   });
+
+  describe('listParticipantActivitiesCompletionForProgram', () => {
+    // const programId = 1;
+    // const principalId = 3;
+    it('should return a list of participant activities with their completion statuses', async () => {
+      return;
+    });
+    it('should return null if the programId does not exist', async () => {
+      return;
+    });
+  });
 });

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -7,7 +7,6 @@ import {
   ActivityType,
 } from '../models';
 import { DateTime, Duration } from 'luxon';
-import { participantExists } from './meetingsService';
 
 /**
  * Returns all programs in the database.
@@ -397,16 +396,19 @@ export const listParticipantActivitiesCompletionForProgram = async (
   principalId: number,
   programId: number
 ) => {
-  // TODO: get all `participant_activities` records for the principalId and programId
-  // { programId: number, participant_activities: { activityId: number, completed: boolean} }
-  const result = await db('participant_activities')
-    .select('activityId', 'completed')
-    .where({
-      program_id: programId,
-      principal_id: principalId,
-    });
+  let result;
+  try {
+    result = await db('participant_activities')
+      .select('activity_id', 'completed')
+      .where({
+        program_id: programId,
+        principal_id: principalId,
+      });
+  } catch (e) {
+    return null;
+  }
 
-  if (!programId) {
+  if (!result) {
     return null;
   }
 

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -7,6 +7,7 @@ import {
   ActivityType,
 } from '../models';
 import { DateTime, Duration } from 'luxon';
+import { participantExists } from './meetingsService';
 
 /**
  * Returns all programs in the database.
@@ -383,4 +384,31 @@ export const setParticipantActivityCompletion = async (
     participantActivityId: participantActivity.id,
     completed: participantActivity.completed === 1,
   };
+};
+
+//  * Get the completion status (either true or false) of all activities of type assignment in a given program.
+//  *
+//  * @param {number} principalId - the unique id for the user
+//  * @param {number} programId - the id for the unique program
+//  * @returns List of participant_activities and their completion statuses,
+//  *   or null if programId doesn't exist or it doesn't have activities
+//  */
+export const listParticipantActivitiesCompletionForProgram = async (
+  principalId: number,
+  programId: number
+) => {
+  // TODO: get all `participant_activities` records for the principalId and programId
+  // { programId: number, participant_activities: { activityId: number, completed: boolean} }
+  const result = await db('participant_activities')
+    .select('activityId', 'completed')
+    .where({
+      program_id: programId,
+      principal_id: principalId,
+    });
+
+  if (!programId) {
+    return null;
+  }
+
+  return { programId: programId, participantActivities: result };
 };

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -403,9 +403,5 @@ export const listParticipantActivitiesCompletionForProgram = async (
       principal_id: principalId,
     });
 
-  if (!participantActivities) {
-    return null;
-  }
-
   return { programId: programId, participantActivities };
 };

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -396,21 +396,16 @@ export const listParticipantActivitiesCompletionForProgram = async (
   principalId: number,
   programId: number
 ) => {
-  let result;
-  try {
-    result = await db('participant_activities')
-      .select('activity_id', 'completed')
-      .where({
-        program_id: programId,
-        principal_id: principalId,
-      });
-  } catch (e) {
+  const participantActivities = await db('participant_activities')
+    .select('activity_id', 'completed')
+    .where({
+      program_id: programId,
+      principal_id: principalId,
+    });
+
+  if (!participantActivities) {
     return null;
   }
 
-  if (!result) {
-    return null;
-  }
-
-  return { programId: programId, participantActivities: result };
+  return { programId: programId, participantActivities };
 };


### PR DESCRIPTION
## Proposed changes
This PR resolves #469 .

This PR adds a "listParticipantActivitiesCompletionForProgram" service function and a router for it. It takes the program and principle ID as parameters, and return all corresponding activities with their completion status.

Test files for both service function and router are 100% passed.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
