### PR TITLE
#488 Pre-fill participant activities for existing users upon calendar page load

### DIFF
--- a/api/src/middleware/programsRouter.ts
+++ b/api/src/middleware/programsRouter.ts
@@ -11,9 +11,10 @@ import {
 const programsRouter = Router();
 
 programsRouter.get('/', async (req, res, next) => {
+  const { principalId } = req.session;
   let programsWithActivities;
   try {
-    programsWithActivities = await listProgramsWithActivities();
+    programsWithActivities = await listProgramsWithActivities(principalId);
   } catch (error) {
     next(error);
     return;

--- a/api/src/models.d.ts
+++ b/api/src/models.d.ts
@@ -55,7 +55,7 @@ export interface ActivityType {
   updated_at?: string;
 }
 
-export interface ParticipantActivities {
+export interface ParticipantActivity {
   id: number;
   program_id: number;
   activity_id: number;

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -469,13 +469,12 @@ describe('programsService', () => {
   });
 
   describe('checkForPrefill', () => {
+    const programsWithActivities: ProgramWithActivities[] = [
+      { ...programsList[0], activities: programActivitiesList[0] },
+      { ...programsList[1], activities: programActivitiesList[1] },
+      { ...programsList[2], activities: programActivitiesList[2] },
+    ];
     it('should insert missing participant activities', async () => {
-      const programsWithActivities: ProgramWithActivities[] = [
-        { ...programsList[0], activities: programActivitiesList[0] },
-        { ...programsList[1], activities: programActivitiesList[1] },
-        { ...programsList[2], activities: programActivitiesList[2] },
-      ];
-
       mockQuery(
         'select `program_id`, `activity_id`, `principal_id`, `completed` from `participant_activities` where `principal_id` = ?',
         [participantActivitiesList[0].principal_id],
@@ -495,6 +494,21 @@ describe('programsService', () => {
           participantActivitiesList[2].program_id,
         ],
         []
+      );
+
+      expect(
+        await checkForPrefill(
+          participantActivitiesList[0].principal_id,
+          programsWithActivities
+        )
+      ).toEqual([]);
+    });
+    
+    it('should do nothing if all assignments in participant_activities have completion status', async () => {
+      mockQuery(
+        'select `program_id`, `activity_id`, `principal_id`, `completed` from `participant_activities` where `principal_id` = ?',
+        [participantActivitiesList[0].principal_id],
+        participantActivitiesList
       );
 
       expect(

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -8,6 +8,7 @@ import {
   listActivityTypes,
   findProgramWithActivities,
   listProgramsForCurriculum,
+  checkForPrefill,
   listProgramsWithActivities,
   getParticipantActivityId,
   getParticipantActivityCompletion,
@@ -451,6 +452,44 @@ describe('programsService', () => {
       expect(await findProgramWithActivities(programId)).toEqual(
         programWithActivities
       );
+    });
+  });
+
+  describe('checkForPrefill', () => {
+    it('should insert missing participant activities', async () => {
+      const programsWithActivities: ProgramWithActivities[] = [
+        { ...programsList[0], activities: programActivitiesList[0] },
+        { ...programsList[1], activities: programActivitiesList[1] },
+        { ...programsList[2], activities: programActivitiesList[2] },
+      ];
+
+      mockQuery(
+        'select `program_id`, `activity_id`, `principal_id`, `completed` from `participant_activities` where `principal_id` = ?',
+        [participantActivitiesList[0].principal_id],
+        [participantActivitiesList[0]]
+      );
+
+      mockQuery(
+        'insert ignore into `participant_activities` (`activity_id`, `completed`, `principal_id`, `program_id`) values (?, ?, ?, ?), (?, ?, ?, ?)',
+        [
+          participantActivitiesList[1].activity_id,
+          false,
+          participantActivitiesList[1].principal_id,
+          participantActivitiesList[1].program_id,
+          participantActivitiesList[2].activity_id,
+          false,
+          participantActivitiesList[2].principal_id,
+          participantActivitiesList[2].program_id,
+        ],
+        []
+      );
+
+      expect(
+        await checkForPrefill(
+          participantActivitiesList[0].principal_id,
+          programsWithActivities
+        )
+      ).toEqual([]);
     });
   });
 

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -19,7 +19,7 @@ import {
   CurriculumActivity,
   ActivityType,
   ProgramWithActivities,
-  ParticipantActivities,
+  ParticipantActivity,
 } from '../../models';
 
 import { mockQuery } from '../mockDb';
@@ -145,7 +145,7 @@ const curriculumActivitiesList: CurriculumActivity[] = [
     updated_at: '2022-11-15 01:23:45',
   },
 ];
-const participantActivitiesList: ParticipantActivities[] = [
+const participantActivitiesList: ParticipantActivity[] = [
   {
     id: 1,
     program_id: 1,

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -503,7 +503,7 @@ describe('programsService', () => {
         )
       ).toEqual([]);
     });
-    
+
     it('should do nothing if all assignments in participant_activities have completion status', async () => {
       mockQuery(
         'select `program_id`, `activity_id`, `principal_id`, `completed` from `participant_activities` where `principal_id` = ?',

--- a/api/src/services/__tests__/programsService.ts
+++ b/api/src/services/__tests__/programsService.ts
@@ -69,7 +69,7 @@ const curriculumActivitiesList: CurriculumActivity[] = [
     start_time: '10:00:00',
     end_time: '11:00:00',
     duration: 60,
-    activity_type_id: 3,
+    activity_type_id: 4,
     curriculum_id: 1,
     created_at: '2022-11-15 01:23:45',
     updated_at: '2022-11-15 01:23:45',
@@ -83,7 +83,7 @@ const curriculumActivitiesList: CurriculumActivity[] = [
     start_time: '11:10:00',
     end_time: '12:00:00',
     duration: 50,
-    activity_type_id: 1,
+    activity_type_id: 9,
     curriculum_id: 1,
     created_at: '2022-11-15 01:23:45',
     updated_at: '2022-11-15 01:23:45',
@@ -97,7 +97,7 @@ const curriculumActivitiesList: CurriculumActivity[] = [
     start_time: null,
     end_time: null,
     duration: null,
-    activity_type_id: 2,
+    activity_type_id: 1,
     curriculum_id: 1,
     created_at: '2022-11-15 01:23:45',
     updated_at: '2022-11-15 01:23:45',
@@ -111,7 +111,7 @@ const curriculumActivitiesList: CurriculumActivity[] = [
     start_time: '10:00:00',
     end_time: '11:00:00',
     duration: 60,
-    activity_type_id: 3,
+    activity_type_id: 4,
     curriculum_id: 2,
     created_at: '2022-11-15 01:23:45',
     updated_at: '2022-11-15 01:23:45',
@@ -125,7 +125,7 @@ const curriculumActivitiesList: CurriculumActivity[] = [
     start_time: '11:10:00',
     end_time: '12:00:00',
     duration: 50,
-    activity_type_id: 1,
+    activity_type_id: 9,
     curriculum_id: 2,
     created_at: '2022-11-15 01:23:45"',
     updated_at: '2022-11-15 01:23:45',
@@ -139,7 +139,7 @@ const curriculumActivitiesList: CurriculumActivity[] = [
     start_time: null,
     end_time: null,
     duration: null,
-    activity_type_id: 2,
+    activity_type_id: 1,
     curriculum_id: 2,
     created_at: '2022-11-15 01:23:45',
     updated_at: '2022-11-15 01:23:45',
@@ -149,23 +149,23 @@ const participantActivitiesList: ParticipantActivity[] = [
   {
     id: 1,
     program_id: 1,
-    activity_id: 7,
-    principal_id: 3,
+    activity_id: 3,
+    principal_id: 2,
     completed: false,
   },
   {
     id: 2,
-    program_id: 1,
-    activity_id: 8,
-    principal_id: 3,
-    completed: false,
+    program_id: 2,
+    activity_id: 6,
+    principal_id: 2,
+    completed: true,
   },
   {
     id: 3,
-    program_id: 1,
-    activity_id: 10,
-    principal_id: 3,
-    completed: true,
+    program_id: 3,
+    activity_id: 3,
+    principal_id: 2,
+    completed: false,
   },
 ];
 const programActivitiesList: ProgramActivity[][] = [
@@ -185,7 +185,7 @@ const programActivitiesList: ProgramActivity[][] = [
       description_text: 'Get to know each other.',
       program_id: 1,
       curriculum_activity_id: 2,
-      activity_type: 'class',
+      activity_type: 'other meeting',
       start_time: '2022-10-24T18:10:00.000Z',
       end_time: '2022-10-24T19:00:00.000Z',
       duration: 50,
@@ -217,7 +217,7 @@ const programActivitiesList: ProgramActivity[][] = [
       description_text: 'Get to know each other.',
       program_id: 2,
       curriculum_activity_id: 5,
-      activity_type: 'class',
+      activity_type: 'other meeting',
       start_time: '2022-10-24T18:10:00.000Z',
       end_time: '2022-10-24T19:00:00.000Z',
       duration: 50,
@@ -249,7 +249,7 @@ const programActivitiesList: ProgramActivity[][] = [
       description_text: 'Get to know each other.',
       program_id: 3,
       curriculum_activity_id: 2,
-      activity_type: 'class',
+      activity_type: 'other meeting',
       start_time: '2023-01-02T19:10:00.000Z',
       end_time: '2023-01-02T20:00:00.000Z',
       duration: 50,
@@ -269,25 +269,55 @@ const programActivitiesList: ProgramActivity[][] = [
 const activityTypesList: ActivityType[] = [
   {
     id: 1,
-    title: 'class',
-    created_at: '2022-11-15 01:23:45',
-    updated_at: '2022-11-15 01:23:45',
-  },
-  {
-    id: 2,
     title: 'assignment',
     created_at: '2022-11-15 01:23:45',
     updated_at: '2022-11-15 01:23:45',
   },
   {
+    id: 2,
+    title: 'all-day activity',
+    created_at: '2022-11-15 01:23:45',
+    updated_at: '2022-11-15 01:23:45',
+  },
+  {
     id: 3,
-    title: 'standup',
+    title: 'planning',
     created_at: '2022-11-15 01:23:45',
     updated_at: '2022-11-15 01:23:45',
   },
   {
     id: 4,
+    title: 'standup',
+    created_at: '2022-11-15 01:23:45',
+    updated_at: '2022-11-15 01:23:45',
+  },
+  {
+    id: 5,
+    title: 'bulk development',
+    created_at: '2022-11-15 01:23:45',
+    updated_at: '2022-11-15 01:23:45',
+  },
+  {
+    id: 6,
+    title: 'office hours',
+    created_at: '2022-11-15 01:23:45',
+    updated_at: '2022-11-15 01:23:45',
+  },
+  {
+    id: 7,
+    title: 'workshop',
+    created_at: '2022-11-15 01:23:45',
+    updated_at: '2022-11-15 01:23:45',
+  },
+  {
+    id: 8,
     title: 'retrospective',
+    created_at: '2022-11-15 01:23:45',
+    updated_at: '2022-11-15 01:23:45',
+  },
+  {
+    id: 9,
+    title: 'other meeting',
     created_at: '2022-11-15 01:23:45',
     updated_at: '2022-11-15 01:23:45',
   },
@@ -454,7 +484,7 @@ describe('programsService', () => {
   });
 
   describe('getParticipantActivityId', () => {
-    const principalId = 3;
+    const principalId = 2;
     const programId = 1;
     const activityId = 7;
     it('should return the ID of an existing row in the table', async () => {
@@ -481,7 +511,7 @@ describe('programsService', () => {
   });
 
   describe('getParticipantActivityCompletion', () => {
-    const principalId = 3;
+    const principalId = 2;
     const programId = 1;
     const activityId = 10;
     it('should return an object of completion status being true for a completed activity by a participant', async () => {
@@ -547,7 +577,7 @@ describe('programsService', () => {
   });
 
   describe('setParticipantActivityCompletion', () => {
-    const principalId = 3;
+    const principalId = 2;
     const programId = 1;
     const activityId = 7;
     const activityId2 = 9;

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -273,6 +273,10 @@ export const findProgramWithActivities = async (programId: number) => {
  *
  * @param {number} principalId - restrict result to programs with which the
  *   user is associated
+ * @param {ProgramWithActivities[]} programsWithActivities - list of programs
+ *   with which user is associated, and their associated activities
+ * @returns {Array} - default return value from a database insert; leaving in
+ *   to make function easier to test with Jest
  */
 export const checkForPrefill = async (
   principalId?: number,

--- a/api/src/services/programsService.ts
+++ b/api/src/services/programsService.ts
@@ -322,10 +322,14 @@ export const checkForPrefill = async (
     }
   }
 
-  return await db('participant_activities')
-    .insert(rowsToInsert)
-    .onConflict(['program_id', 'principal_id', 'activity_id'])
-    .ignore();
+  if (rowsToInsert.length > 0) {
+    return await db('participant_activities')
+      .insert(rowsToInsert)
+      .onConflict(['program_id', 'principal_id', 'activity_id'])
+      .ignore();
+  } else {
+    return [];
+  }
 };
 
 /**

--- a/db/migration/V020__insert_default_activities.sql
+++ b/db/migration/V020__insert_default_activities.sql
@@ -7,8 +7,7 @@ INSERT INTO curriculums (principal_id, title) VALUES
 SET @curriculumId = LAST_INSERT_ID();
 
 INSERT INTO programs (title, start_date, end_date, time_zone, principal_id, curriculum_id) VALUES
-  ('Cohort 4', '2022-10-24', '2022-12-16', 'America/Vancouver', @principalId, @curriculumId),
-  ('Cohort 5', '2023-01-23', '2023-03-24', 'America/Vancouver', @principalId, @curriculumId);
+  ('Cohort 4', '2022-10-24', '2022-12-16', 'America/Vancouver', @principalId, @curriculumId);
 
 INSERT INTO activities (title, description_text, curriculum_week, curriculum_day, start_time, end_time, duration, activity_type_id, curriculum_id) VALUES
 -- Week 1, Day 1:


### PR DESCRIPTION
## Proposed changes

These changes resolve #488 by doing the following:

- This removes Cohort 5 from the database migration.
- This pre-fills the `participant_activities` table for each user when they load the calendar page for the first time.

The latter functionality was achieved in code rather than with a stored procedure / migration. This was done in order to adapt best to both environments—live and development—and for code maintainability and testing purposes. Additionally, this minimizes the number of database inserts that need to be done by doing them only on an as-needed basis.

To reiterate, this functionality is only here until we build an admin feature for the participant activities and can associate users with specific programs. When that happens, this code can be removed.

This pull request also updates some out-of-date sample data in the `programsService.ts` test file, and it updates the name of one of the models to better conform to the naming conventions the other models follow.

## Checklist

- [x] Are the issues being addressed linked to this PR?
- [x] Do all commit messages start with the issue number?
- [x] Are all code changes sufficiently tested?
- [x] Are there screenshots for UI changes?
