### PR TITLE
#504 Database structure should be changed to support the assessments feature

### DIFF
--- a/db/migration/V021__create_assessments.sql
+++ b/db/migration/V021__create_assessments.sql
@@ -1,4 +1,3 @@
-
 CREATE TABLE assessment_question_types (
   id BIGINT NOT NULL AUTO_INCREMENT,
   title TEXT NOT NULL,

--- a/db/migration/V021__create_assessments.sql
+++ b/db/migration/V021__create_assessments.sql
@@ -75,7 +75,7 @@ CREATE TABLE assessment_questions (
   assessment_id BIGINT NOT NULL,
   title TEXT NOT NULL,
   description TEXT,
-  assessment_question_type_id BIGINT NOT NULL,
+  question_type_id BIGINT NOT NULL,
   correct_answer_id BIGINT,
   max_score INT,
   sort_order INT NOT NULL,
@@ -83,8 +83,8 @@ CREATE TABLE assessment_questions (
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   INDEX assessment_answers_assessment_question_id (assessment_id),
   FOREIGN KEY (assessment_id) REFERENCES curriculum_assessments(id) ON DELETE CASCADE,
-  INDEX assessment_questions_assessment_question_type_id (assessment_question_type_id),
-  FOREIGN KEY (assessment_question_type_id) REFERENCES assessment_question_types(id),
+  INDEX assessment_questions_question_type_id (question_type_id),
+  FOREIGN KEY (question_type_id) REFERENCES assessment_question_types(id),
   PRIMARY KEY (id),
   UNIQUE KEY `assessment_and_question_number` (`assessment_id`,`sort_order`)
 );

--- a/db/migration/V021__create_assessments.sql
+++ b/db/migration/V021__create_assessments.sql
@@ -1,4 +1,3 @@
-
 CREATE TABLE question_types (
   id BIGINT NOT NULL AUTO_INCREMENT,
   title TEXT NOT NULL,

--- a/db/migration/V021__create_assessments.sql
+++ b/db/migration/V021__create_assessments.sql
@@ -1,3 +1,22 @@
+
+CREATE TABLE question_types (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  title TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE assessment_submission_states (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  title TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE program_participant_roles (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  title TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
 CREATE TABLE curriculum_assessments (
   id BIGINT NOT NULL AUTO_INCREMENT,
   title TEXT NOT NULL,
@@ -115,21 +134,5 @@ CREATE TABLE assessment_responses (
   FOREIGN KEY (question_id) REFERENCES assessment_questions(id),
   INDEX assessment_responses_answer_id (answer_id),
   FOREIGN KEY (answer_id) REFERENCES assessment_answers(id),
-  PRIMARY KEY (id)
-);
-
-CREATE TABLE question_types (
-  id BIGINT NOT NULL AUTO_INCREMENT,
-  title TEXT NOT NULL,
-  PRIMARY KEY (id)
-);
-
-CREATE TABLE assessment_submission_states (
-  id BIGINT NOT NULL AUTO_INCREMENT,
-  PRIMARY KEY (id)
-);
-
-CREATE TABLE program_participant_roles (
-  id BIGINT NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (id)
 );

--- a/db/migration/V021__create_assessments.sql
+++ b/db/migration/V021__create_assessments.sql
@@ -1,0 +1,135 @@
+CREATE TABLE curriculum_assessments (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  title TEXT NOT NULL,
+  description TEXT,
+  max_score INT NOT NULL,
+  max_num_submissions INT NOT NULL,
+  time_limit INT,
+  curriculum_id BIGINT NOT NULL,
+  activity_id BIGINT NOT NULL,
+  principal_id BIGINT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX curriculum_assessments_curriculum_id (curriculum_id),
+  FOREIGN KEY (curriculum_id) REFERENCES curriculums(id),
+  INDEX curriculum_assessments_activity_id (activity_id),
+  FOREIGN KEY (activity_id) REFERENCES activities(id),
+  INDEX curriculum_assessments_principal_id (principal_id),
+  FOREIGN KEY (principal_id) REFERENCES principals(id),
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE program_assessments (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  program_id BIGINT NOT NULL,
+  assessment_id BIGINT NOT NULL,
+  available_after TIMESTAMP NOT NULL,
+  due_date TIMESTAMP NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX program_assessments_program_id (program_id),
+  FOREIGN KEY (program_id) REFERENCES programs(id),
+  INDEX program_assessments_assessment_id (assessment_id),
+  FOREIGN KEY (assessment_id) REFERENCES curriculum_assessments(id),
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE program_participants (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  principal_id BIGINT NOT NULL,
+  program_id BIGINT NOT NULL,
+  role_id BIGINT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX program_participants_principal_id (principal_id),
+  FOREIGN KEY (principal_id) REFERENCES principals(id),
+  INDEX program_participants_program_id (program_id),
+  FOREIGN KEY (program_id) REFERENCES programs(id),
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE assessment_submissions (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  assessment_id BIGINT NOT NULL,
+  principal_id BIGINT NOT NULL,
+  state_id BIGINT NOT NULL,
+  score INT,
+  opened_at TIMESTAMP NOT NULL,
+  submitted_at TIMESTAMP NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX assessment_submissions_assessment_id (assessment_id),
+  FOREIGN KEY (assessment_id) REFERENCES program_assessments(id),
+  INDEX assessment_submissions_principal_id (principal_id),
+  FOREIGN KEY (principal_id) REFERENCES principals(id),
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE assessment_questions (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  assessment_id BIGINT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  question_type_id BIGINT NOT NULL,
+  correct_answer_id BIGINT,
+  max_score INT,
+  sort_order INT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX assessment_questions_assessment_id (assessment_id),
+  FOREIGN KEY (assessment_id) REFERENCES curriculum_assessments(id),
+  INDEX assessment_questions_question_type_id (question_type_id),
+  FOREIGN KEY (question_type_id) REFERENCES question_types(id),
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE assessment_answers (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  question_id BIGINT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT NOT NULL,
+  sort_order INT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX assessment_answers_question_id (question_id),
+  FOREIGN KEY (question_id) REFERENCES assessment_questions(id),
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE assessment_responses (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  assessment_id BIGINT NOT NULL,
+  submission_id BIGINT NOT NULL,
+  question_id BIGINT NOT NULL,
+  answer_id BIGINT,
+  response TEXT,
+  score INT,
+  grader_response TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX assessment_responses_assessment_id (assessment_id),
+  FOREIGN KEY (assessment_id) REFERENCES program_assessments(id),
+  INDEX assessment_responses_submission_id (submission_id),
+  FOREIGN KEY (submission_id) REFERENCES assessment_submissions(id),
+  INDEX assessment_responses_question_id (question_id),
+  FOREIGN KEY (question_id) REFERENCES assessment_questions(id),
+  INDEX assessment_responses_answer_id (answer_id),
+  FOREIGN KEY (answer_id) REFERENCES assessment_answers(id),
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE question_types (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  title TEXT NOT NULL,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE assessment_submission_states (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (id)
+);
+
+CREATE TABLE program_participant_roles (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (id)
+);

--- a/db/migration/V021__create_assessments.sql
+++ b/db/migration/V021__create_assessments.sql
@@ -29,7 +29,7 @@ CREATE TABLE program_participants (
   INDEX program_participants_program_id (program_id),
   FOREIGN KEY (program_id) REFERENCES programs(id) ON DELETE CASCADE,
   INDEX program_participants_role_id (role_id),
-  FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE SET NULL,
+  FOREIGN KEY (role_id) REFERENCES program_participant_roles(id) ON DELETE SET NULL,
   PRIMARY KEY (id),
   UNIQUE KEY `principals_and_programs` (`principal_id`,`program_id`)
 );
@@ -81,13 +81,11 @@ CREATE TABLE assessment_questions (
   max_score INT,
   sort_order INT NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP ON DELETE CASCADE,
-  INDEX assessment_questions_assessment_id (assessment_id),
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX assessment_answers_assessment_question_id (assessment_id),
   FOREIGN KEY (assessment_id) REFERENCES curriculum_assessments(id) ON DELETE CASCADE,
   INDEX assessment_questions_assessment_question_type_id (assessment_question_type_id),
   FOREIGN KEY (assessment_question_type_id) REFERENCES assessment_question_types(id),
-  INDEX assessment_questions_correct_answer_id (correct_answer_id),
-  FOREIGN KEY (correct_answer_id) REFERENCES correct_answers(id) ON DELETE SET NULL,
   PRIMARY KEY (id),
   UNIQUE KEY `assessment_and_question_number` (`assessment_id`,`sort_order`)
 );

--- a/db/migration/V021__create_assessments.sql
+++ b/db/migration/V021__create_assessments.sql
@@ -1,5 +1,5 @@
 
-CREATE TABLE question_types (
+CREATE TABLE assessment_question_types (
   id BIGINT NOT NULL AUTO_INCREMENT,
   title TEXT NOT NULL,
   PRIMARY KEY (id)
@@ -17,22 +17,39 @@ CREATE TABLE program_participant_roles (
   PRIMARY KEY (id)
 );
 
+CREATE TABLE program_participants (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  principal_id BIGINT NOT NULL,
+  program_id BIGINT NOT NULL,
+  role_id BIGINT,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX program_participants_principal_id (principal_id),
+  FOREIGN KEY (principal_id) REFERENCES principals(id),
+  INDEX program_participants_program_id (program_id),
+  FOREIGN KEY (program_id) REFERENCES programs(id) ON DELETE CASCADE,
+  INDEX program_participants_role_id (role_id),
+  FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE SET NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY `principals_and_programs` (`principal_id`,`program_id`)
+);
+
 CREATE TABLE curriculum_assessments (
   id BIGINT NOT NULL AUTO_INCREMENT,
   title TEXT NOT NULL,
-  description TEXT,
-  max_score INT NOT NULL,
-  max_num_submissions INT NOT NULL,
+  description TEXT NOT NULL,
+  max_score INT,
+  max_num_submissions INT NOT NULL DEFAULT 1,
   time_limit INT,
   curriculum_id BIGINT NOT NULL,
-  activity_id BIGINT NOT NULL,
+  activity_id BIGINT NULL,
   principal_id BIGINT NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   INDEX curriculum_assessments_curriculum_id (curriculum_id),
-  FOREIGN KEY (curriculum_id) REFERENCES curriculums(id),
+  FOREIGN KEY (curriculum_id) REFERENCES curriculums(id) ON DELETE CASCADE,
   INDEX curriculum_assessments_activity_id (activity_id),
-  FOREIGN KEY (activity_id) REFERENCES activities(id),
+  FOREIGN KEY (activity_id) REFERENCES activities(id) ON DELETE SET NULL,
   INDEX curriculum_assessments_principal_id (principal_id),
   FOREIGN KEY (principal_id) REFERENCES principals(id),
   PRIMARY KEY (id)
@@ -47,41 +64,11 @@ CREATE TABLE program_assessments (
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   INDEX program_assessments_program_id (program_id),
-  FOREIGN KEY (program_id) REFERENCES programs(id),
+  FOREIGN KEY (program_id) REFERENCES programs(id) ON DELETE CASCADE,
   INDEX program_assessments_assessment_id (assessment_id),
-  FOREIGN KEY (assessment_id) REFERENCES curriculum_assessments(id),
-  PRIMARY KEY (id)
-);
-
-CREATE TABLE program_participants (
-  id BIGINT NOT NULL AUTO_INCREMENT,
-  principal_id BIGINT NOT NULL,
-  program_id BIGINT NOT NULL,
-  role_id BIGINT NOT NULL,
-  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  INDEX program_participants_principal_id (principal_id),
-  FOREIGN KEY (principal_id) REFERENCES principals(id),
-  INDEX program_participants_program_id (program_id),
-  FOREIGN KEY (program_id) REFERENCES programs(id),
-  PRIMARY KEY (id)
-);
-
-CREATE TABLE assessment_submissions (
-  id BIGINT NOT NULL AUTO_INCREMENT,
-  assessment_id BIGINT NOT NULL,
-  principal_id BIGINT NOT NULL,
-  state_id BIGINT NOT NULL,
-  score INT,
-  opened_at TIMESTAMP NOT NULL,
-  submitted_at TIMESTAMP NOT NULL,
-  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  INDEX assessment_submissions_assessment_id (assessment_id),
-  FOREIGN KEY (assessment_id) REFERENCES program_assessments(id),
-  INDEX assessment_submissions_principal_id (principal_id),
-  FOREIGN KEY (principal_id) REFERENCES principals(id),
-  PRIMARY KEY (id)
+  FOREIGN KEY (assessment_id) REFERENCES curriculum_assessments(id) ON DELETE CASCADE,
+  PRIMARY KEY (id),
+  UNIQUE KEY `program_and_assessment` (`program_id`,`assessment_id`)
 );
 
 CREATE TABLE assessment_questions (
@@ -89,29 +76,52 @@ CREATE TABLE assessment_questions (
   assessment_id BIGINT NOT NULL,
   title TEXT NOT NULL,
   description TEXT,
-  question_type_id BIGINT NOT NULL,
+  assessment_question_type_id BIGINT NOT NULL,
   correct_answer_id BIGINT,
   max_score INT,
   sort_order INT NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP ON DELETE CASCADE,
   INDEX assessment_questions_assessment_id (assessment_id),
-  FOREIGN KEY (assessment_id) REFERENCES curriculum_assessments(id),
-  INDEX assessment_questions_question_type_id (question_type_id),
-  FOREIGN KEY (question_type_id) REFERENCES question_types(id),
-  PRIMARY KEY (id)
+  FOREIGN KEY (assessment_id) REFERENCES curriculum_assessments(id) ON DELETE CASCADE,
+  INDEX assessment_questions_assessment_question_type_id (assessment_question_type_id),
+  FOREIGN KEY (assessment_question_type_id) REFERENCES assessment_question_types(id),
+  INDEX assessment_questions_correct_answer_id (correct_answer_id),
+  FOREIGN KEY (correct_answer_id) REFERENCES correct_answers(id) ON DELETE SET NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY `assessment_and_question_number` (`assessment_id`,`sort_order`)
 );
 
 CREATE TABLE assessment_answers (
   id BIGINT NOT NULL AUTO_INCREMENT,
-  question_id BIGINT NOT NULL,
+  question_id BIGINT,
   title TEXT NOT NULL,
-  description TEXT NOT NULL,
+  description TEXT,
   sort_order INT NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   INDEX assessment_answers_question_id (question_id),
-  FOREIGN KEY (question_id) REFERENCES assessment_questions(id),
+  FOREIGN KEY (question_id) REFERENCES assessment_questions(id) ON DELETE CASCADE,
+  PRIMARY KEY (id),
+  UNIQUE KEY `question_and_answer_order` (`question_id`,`sort_order`)
+);
+
+CREATE TABLE assessment_submissions (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  assessment_id BIGINT NOT NULL,
+  principal_id BIGINT NOT NULL,
+  assessment_submission_state_id BIGINT NOT NULL,
+  score INT,
+  opened_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  submitted_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX assessment_submissions_assessment_id (assessment_id),
+  FOREIGN KEY (assessment_id) REFERENCES program_assessments(id),
+  INDEX assessment_submissions_principal_id (principal_id),
+  FOREIGN KEY (principal_id) REFERENCES principals(id),
+  INDEX assessment_submissions_assessment_submission_state_id (assessment_submission_state_id),
+  FOREIGN KEY (assessment_submission_state_id) REFERENCES assessment_submission_states(id),
   PRIMARY KEY (id)
 );
 
@@ -133,6 +143,16 @@ CREATE TABLE assessment_responses (
   INDEX assessment_responses_question_id (question_id),
   FOREIGN KEY (question_id) REFERENCES assessment_questions(id),
   INDEX assessment_responses_answer_id (answer_id),
-  FOREIGN KEY (answer_id) REFERENCES assessment_answers(id),
-  PRIMARY KEY (id)
+  FOREIGN KEY (answer_id) REFERENCES assessment_answers(id) ON DELETE SET NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY `submission_and_question` (`submission_id`,`question_id`)
 );
+
+ALTER TABLE questionnaires
+RENAME TO surveys;
+
+ALTER TABLE prompts
+RENAME TO survey_questions;
+
+ALTER TABLE options
+RENAME TO survey_answers;


### PR DESCRIPTION
## Proposed changes

These changes resolve #504 by setting up the structure of the database tables needed for the assessments feature (as defined in the ERD) in a new migration file. The tables to be added:

`question_types` - Defines the types of answers we can support in the app, like "multiple choice" and "free response"
`assessment_submission_states` - Defines the states of a submission, like "draft" and "submitted" and "graded"
`program_participant_roles` - Defines the permissions role of a participant enrolled in a course, like "participant" or "facilitator"
`curriculum_assessments` - List of all assessments (assignments, quizzes, tests) defined in the system for all curricula
`program_assessments` - List of all assessment instances for each program/term of each curriculum
`program_participants` - Associations between principals and programs to create participants
`assessment_questions` - List of all questions used in every assessment
`assessment_answers` - List of all multiple-choice (or other) answer available for all questions
`assessment_submissions` - List of all submissions for every assessment instance and by each program participant
`assessment_responses` - List of all answers given by participants for each submission as well as feedback about their answer given by program facilitators

## Checklist

- [x] Related issue appears at beginning of pull request title with pound sign, and title describes the changes being proposed.
- [x] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] The appropriate label has been chosen for this pull request.
- [x] The correct project has been selected for this pull request.
- [x] All commits in this branch, including merge commits, begin with the issue number and a pound sign.
- [x] Tests have been added, where appropriate; or, no tests are relevant for this pull request.
- [x] This pull request contains UI changes, and screenshots of those UI images appear below; or, this pull request contains no UI changes.
