### PR TITLE
#521 Add the tests for assessmentsRouter

### DIFF
--- a/api/src/middleware/__tests__/assessmentsRouter.ts
+++ b/api/src/middleware/__tests__/assessmentsRouter.ts
@@ -1,0 +1,96 @@
+import { itemEnvelope } from '../responseEnvelope';
+import { createAppAgentForRouter } from '../routerTestUtils';
+import assessmentsRouter from '../assessmentsRouter';
+
+describe('assessmentsRouter', () => {
+  const appAgent = createAppAgentForRouter(assessmentsRouter);
+  const exampleAssessmentId = 1;
+  const exampleSubmissionId = 1;
+
+  describe('GET /', () => {
+    it('should respond with a list of all assessments', done => {
+      const response = { behaviour: 'Shows a list of all assessments' };
+      appAgent.get('/').expect(200, itemEnvelope(response), err => {
+        done(err);
+      });
+    });
+  });
+
+  describe('POST /', () => {
+    it('should create a new assessment', done => {
+      const response = { behaviour: 'Creates a new assessment' };
+      appAgent.post('/').expect(200, itemEnvelope(response), err => {
+        done(err);
+      });
+    });
+  });
+
+  describe('GET /:assessmentId', () => {
+    it('should show a single assessment', done => {
+      const response = { behaviour: 'Shows a single assessment' };
+      appAgent
+        .get(`/${exampleAssessmentId}`)
+        .expect(200, itemEnvelope(response), err => {
+          done(err);
+        });
+    });
+  });
+
+  describe('PUT /:assessmentId', () => {
+    it('should edit an assessment in the system', done => {
+      const response = { behaviour: 'Edits an assessment in the system' };
+      appAgent
+        .put(`/${exampleAssessmentId}`)
+        .expect(200, itemEnvelope(response), err => {
+          done(err);
+        });
+    });
+  });
+
+  describe('DELETE /:assessmentId', () => {
+    it('should delete an assessment in the system', done => {
+      const response = { behaviour: '“Deletes” an assessment in the system' };
+      appAgent
+        .delete(`/${exampleAssessmentId}`)
+        .expect(200, itemEnvelope(response), err => {
+          done(err);
+        });
+    });
+  });
+
+  describe('GET /:assessmentId/submissions/:submissionId', () => {
+    it('should return the submission information', done => {
+      const response = {
+        behaviour:
+          'Returns the submission information (metadata, answers, etc)',
+      };
+      appAgent
+        .get(`/${exampleAssessmentId}/submissions/${exampleSubmissionId}`)
+        .expect(200, itemEnvelope(response), err => {
+          done(err);
+        });
+    });
+  });
+
+  describe('PUT /:assessmentId/submissions/:submissionId', () => {
+    it('should update the state of a submission', done => {
+      const response = { behaviour: 'Updates the state of a submission' };
+      appAgent
+        .put(`/${exampleAssessmentId}/submissions/${exampleSubmissionId}`)
+        .expect(200, itemEnvelope(response), err => {
+          done(err);
+        });
+    });
+  });
+
+  describe('GET /:assessmentId/submissions/new', () => {
+    it('should create a new draft submission', done => {
+      const response = { behaviour: 'Creates a new draft submission' };
+      appAgent
+        .get(`/${exampleAssessmentId}/submissions/new`)
+        .expect(200, itemEnvelope(response), err => {
+          done(err);
+        });
+    });
+  });
+});

--- a/api/src/middleware/__tests__/programsRouter.ts
+++ b/api/src/middleware/__tests__/programsRouter.ts
@@ -255,4 +255,20 @@ describe('programsRouter', () => {
         .expect(500, done);
     });
   });
+
+  describe('GET /:programId/certificate/:principal_id', () => {
+    it('should retrieve program completion information of a participant.', done => {
+      const programId = 1;
+      const principalId = 3;
+
+      const response = {
+        behaviour: 'Retrieves program completion information of a participant.',
+      };
+      appAgent
+        .get(`/${programId}/certificate/${principalId}`)
+        .expect(200, itemEnvelope(response), err => {
+          done(err);
+        });
+    });
+  });
 });

--- a/api/src/middleware/assessmentsRouter.ts
+++ b/api/src/middleware/assessmentsRouter.ts
@@ -28,6 +28,11 @@ assessmentsRouter.delete('/:assessmentId', (req, res) => {
   res.status(200).json(itemEnvelope(response));
 });
 
+assessmentsRouter.get('/:assessmentId/submissions/new', (req, res) => {
+  const response = { behaviour: 'Creates a new draft submission' };
+  res.status(200).json(itemEnvelope(response));
+});
+
 assessmentsRouter.get(
   '/:assessmentId/submissions/:submissionId',
   (req, res) => {
@@ -45,10 +50,5 @@ assessmentsRouter.put(
     res.status(200).json(itemEnvelope(response));
   }
 );
-
-assessmentsRouter.get('/:assessmentId/submissions/new', (req, res) => {
-  const response = { behaviour: 'Creates a new draft submission' };
-  res.status(200).json(itemEnvelope(response));
-});
 
 export default assessmentsRouter;


### PR DESCRIPTION
## Proposed changes

This resolves #521 by adding tests for the new routes that are in `assessmentsRouter.ts` and `programsRouter.ts`. However, these tests are only for the basic version of these routes and will need to be updated once tickets #515 and #517 are complete.

## Checklist

- [x] Related issue appears at beginning of pull request title with pound sign, and title describes the changes being proposed.
- [x] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] The appropriate label has been chosen for this pull request.
- [x] The correct project has been selected for this pull request.
- [x] All commits in this branch, including merge commits, begin with the issue number and a pound sign.
- [x] Tests have been added, where appropriate; or, no tests are relevant for this pull request.
- [x] This pull request contains UI changes, and screenshots of those UI images appear below; or, this pull request contains no UI changes.
