### PR TITLE
#523 Fix the reflections survey feature to use the renamed tables

### DIFF
--- a/api/src/services/__tests__/questionnairesService.ts
+++ b/api/src/services/__tests__/questionnairesService.ts
@@ -14,17 +14,17 @@ describe('questionnairesService', () => {
       };
       const options = [{ id: 3, label: 'option label', prompt_id: promptId }];
       mockQuery(
-        'select `id` from `questionnaires` where `id` = ?',
+        'select `id` from `surveys` where `id` = ?',
         [questionnaireId],
         [questionnaire]
       );
       mockQuery(
-        'select `id`, `label`, `query_text` from `prompts` where `questionnaire_id` = ? order by `sort_order` asc',
+        'select `id`, `label`, `query_text` from `survey_questions` where `questionnaire_id` = ? order by `sort_order` asc',
         [questionnaireId],
         [prompt]
       );
       mockQuery(
-        'select `id`, `label`, `prompt_id` from `options` where `prompt_id` in (?) order by `prompt_id` asc',
+        'select `id`, `label`, `prompt_id` from `survey_answers` where `prompt_id` in (?) order by `prompt_id` asc',
         [promptId],
         options
       );
@@ -37,7 +37,7 @@ describe('questionnairesService', () => {
     it('should return null if no questionnaire was found with the given id', async () => {
       const questionnaireId = 1;
       mockQuery(
-        'select `id` from `questionnaires` where `id` = ?',
+        'select `id` from `surveys` where `id` = ?',
         [questionnaireId],
         []
       );

--- a/api/src/services/__tests__/reflectionsService.ts
+++ b/api/src/services/__tests__/reflectionsService.ts
@@ -58,7 +58,7 @@ describe('reflectionsService', () => {
         journalEntries
       );
       mockQuery(
-        'select `responses`.`id` as `id`, `reflection_id` as `reflection_id`, `option_id` as `option_id`, `options`.`label` as `option_label`, `prompt_id` as `prompt_id`, `prompts`.`label` as `prompt_label` from `responses` inner join `options` on `responses`.`option_id` = `options`.`id` inner join `prompts` on `options`.`prompt_id` = `prompts`.`id` where `reflection_id` in (?) order by `prompts`.`sort_order` asc',
+        'select `responses`.`id` as `id`, `reflection_id` as `reflection_id`, `option_id` as `option_id`, `survey_answers`.`label` as `option_label`, `prompt_id` as `prompt_id`, `survey_questions`.`label` as `prompt_label` from `responses` inner join `survey_answers` on `responses`.`option_id` = `survey_answers`.`id` inner join `survey_questions` on `survey_answers`.`prompt_id` = `survey_questions`.`id` where `reflection_id` in (?) order by `survey_questions`.`sort_order` asc',
         [reflectionId],
         responses
       );

--- a/api/src/services/questionnairesService.ts
+++ b/api/src/services/questionnairesService.ts
@@ -1,13 +1,13 @@
 import db from './db';
 
 export const findQuestionnaire = async (questionnaireId: number) => {
-  const [questionnaire] = await db('questionnaires')
+  const [questionnaire] = await db('surveys')
     .select('id')
     .where({ id: questionnaireId });
   if (!questionnaire) {
     return null;
   }
-  const prompts = await db('prompts')
+  const prompts = await db('survey_questions')
     .select('id', 'label', 'query_text')
     .where({
       questionnaire_id: questionnaireId,
@@ -17,7 +17,7 @@ export const findQuestionnaire = async (questionnaireId: number) => {
   const promptsById = new Map();
   let options;
   if (promptIds.length) {
-    options = await db('options')
+    options = await db('survey_answers')
       .select('id', 'label', 'prompt_id')
       .whereIn('prompt_id', promptIds)
       .orderBy('prompt_id', 'sort_order');

--- a/api/src/services/reflectionsService.ts
+++ b/api/src/services/reflectionsService.ts
@@ -33,14 +33,18 @@ export const listReflections = async (
         id: 'responses.id',
         reflection_id: 'reflection_id',
         option_id: 'option_id',
-        option_label: 'options.label',
+        option_label: 'survey_answers.label',
         prompt_id: 'prompt_id',
-        prompt_label: 'prompts.label',
+        prompt_label: 'survey_questions.label',
       })
-      .join('options', 'responses.option_id', 'options.id')
-      .join('prompts', 'options.prompt_id', 'prompts.id')
+      .join('survey_answers', 'responses.option_id', 'survey_answers.id')
+      .join(
+        'survey_questions',
+        'survey_answers.prompt_id',
+        'survey_questions.id'
+      )
       .whereIn('reflection_id', reflectionIds)
-      .orderBy('prompts.sort_order'),
+      .orderBy('survey_questions.sort_order'),
   ]);
   const reflectionsById = new Map();
   for (const reflection of reflections) {


### PR DESCRIPTION
## Proposed changes

This resolves #523 by renaming the tables referenced in code: `questionnaires` becomes `surveys`, `prompts` becomes `survey_questions`, and `options` becomes `survey_answers`. This pull request also updates the tests to ensure that the mock database queries match up with the new table names as well, leading to 100% code coverage with zero errors.

## Checklist

- [x] Related issue appears at beginning of pull request title with pound sign, and title describes the changes being proposed.
- [x] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] The appropriate label has been chosen for this pull request.
- [x] The correct project has been selected for this pull request.
- [x] All commits in this branch, including merge commits, begin with the issue number and a pound sign.
- [x] Tests have been added, where appropriate; or, no tests are relevant for this pull request.
- [x] This pull request contains UI changes, and screenshots of those UI images appear below; or, this pull request contains no UI changes.
