### PR TITLE
#527 Increase MySQL healthcheck timeout from 2 to 10 minutes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,10 @@ services:
       - "3306:3306"
     healthcheck:
       test: mysql ${MYSQL_DATABASE} --user=${MYSQL_USER} --password='${MYSQL_PASSWORD}' --silent --execute "SELECT 1;"
-      interval: 10s
-      timeout: 10s
-      retries: 12
+      interval: 3s
+      timeout: 3s
+      start_period: 60s
+      retries: 180
   flyway:
     build: ./db/
     command: migrate


### PR DESCRIPTION
## Proposed changes

Previously, the MySQL container would be given two minutes to start before being considered unhealthy. This resolves #527 by increasing this to a wild 9 minutes, plus give ourselves a normal minute to start the container (in which the retries don’t count). Do all this while decreasing latency between healthchecks from 10 seconds to two seconds.

## Checklist

- [x] Related issue appears at beginning of pull request title with pound sign, and title describes the changes being proposed.
- [x] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] The appropriate label has been chosen for this pull request.
- [x] The correct project has been selected for this pull request.
- [x] All commits in this branch, including merge commits, begin with the issue number and a pound sign.
- [x] Tests have been added, where appropriate; or, no tests are relevant for this pull request.
- [x] This pull request contains UI changes, and screenshots of those UI images appear below; or, this pull request contains no UI changes.
