### PR TITLE
#517 Define routes for assessments feature 

### DIFF
--- a/api/src/models.d.ts
+++ b/api/src/models.d.ts
@@ -1,5 +1,3 @@
-import assessmentsRouter from './middleware/assessmentsRouter';
-
 export interface Program {
   id: number;
   title: string;
@@ -75,19 +73,6 @@ export interface ParticipantActivityForProgram {
   participant_activities: ParticipantActivityCompletionStatus[];
 }
 
-export interface CurriculumAssessment {
-  id?: number;
-  title: string;
-  description?: string;
-  max_score: number;
-  max_num_submissions: number;
-  time_limit?: number;
-  curriculum_id: number;
-  activity_id: number;
-  principal_id: number;
-  questions: Question[];
-}
-
 export interface Question {
   assessment_question_id: number;
   id?: number;
@@ -99,6 +84,19 @@ export interface Question {
   correct_answer_id?: number;
   max_score: number;
   sort_order: number;
+}
+
+export interface CurriculumAssessment {
+  id?: number;
+  title: string;
+  description?: string;
+  max_score: number;
+  max_num_submissions: number;
+  time_limit?: number;
+  curriculum_id: number;
+  activity_id: number;
+  principal_id: number;
+  questions: Question[];
 }
 
 export interface Answer {
@@ -125,10 +123,6 @@ export interface ProgramAssessment {
   available_after: string;
   due_date: string;
 }
-
-/**
- * GET /assessments
- */
 
 export interface FacilitatorAssessmentSubmissionsSummary {
   num_participants_with_submissions: number;
@@ -167,11 +161,7 @@ export interface AssessmentSubmission {
   responses?: AssessmentResponses[];
 }
 
-/**
- * GET assessments/:assessmentId
- */
 export interface ProgramSubmittedAssessments {
-  /*(assessment_id: number, program_id: number)*/
   curriculum_assessment: CurriculumAssessment;
   program_assessment: ProgramAssessment;
   submissions: AssessmentSubmission[];
@@ -188,12 +178,7 @@ export interface AssessmentSubmission {
   responses?: AssessmentResponses[];
 }
 
-/**
- * GET /assessments/:assessmentId/submission/:submissionId
- */
-
 export interface ProgramSubmittedAssessments {
-  /*(assessment_id:number, assessment_submission_id:number)*/
   curriculum_assessment: CurriculumAssessment;
   program_assessment: ProgramAssessment;
   submission: AssessmentSubmission;
@@ -209,12 +194,8 @@ export interface AssessmentSubmission {
   responses?: AssessmentResponses[];
 }
 
-/**
- * GET /assessments/:assessmentId/submission/new
- */
-
 export interface DraftProgramAssessment {
-  /*(assessment_id:number)*/ curriculum_assessment: CurriculumAssessment;
+  curriculum_assessment: CurriculumAssessment;
   program_assessment: ProgramAssessment;
   submission: AssessmentSubmission;
 }
@@ -225,42 +206,24 @@ export interface ProgramParticipantCompletionSummary {
   total_score: number;
 }
 
-/**
- * GET /programs/:programId/certificate/:principalId
- */
 export interface ProgramCertificate {
-  completion_summary: boolean;
-  Program_participant_completion_summary: ProgramParticipantCompletionSummary;
+  completion_summary: ProgramParticipantCompletionSummary;
 }
-
-/**
- * POST assessments
- */
 
 export interface NewProgramAssessment {
   curriculum_assessment: CurriculumAssessment;
   program_assessment: ProgramAssessment;
 }
-/**
- * PUT assessments/:assessmentId
- */
 
 export interface EditProgramAssessment {
   curriculum_assessment: CurriculumAssessment;
   program_assessment: ProgramAssessment;
 }
 
-/**
- * DELETE /assessments/:assessmentId
- */
 export interface DeleteProgramAssessment {
-  /*(assessment_id:number)*/ submission: AssessmentSubmission;
+  submission: AssessmentSubmission;
 }
 
-/**
- * PUT /assessments/:assessmentId/submission/:submissionId
- */
 export interface SubmitProgramAssessment {
-  /*(AssessmentSubmission assessment_submission)*/
   submission: AssessmentSubmission;
 }

--- a/api/src/models.d.ts
+++ b/api/src/models.d.ts
@@ -129,7 +129,7 @@ export interface FacilitatorAssessmentSubmissionsSummary {
   num_ungraded_submissions: number;
 }
 
-export interface AssessmentsSummary {
+export interface AssessmentSummary {
   curriculum_assessment: CurriculumAssessment;
   program_assessment: ProgramAssessment;
   submissions_summary:

--- a/api/src/models.d.ts
+++ b/api/src/models.d.ts
@@ -74,8 +74,8 @@ export interface ParticipantActivityForProgram {
 }
 
 export interface Question {
-  assessment_question_id: number;
   id?: number;
+  assessment_question_id: number;
   assessment_id?: number;
   title: string;
   description?: string;
@@ -96,7 +96,7 @@ export interface CurriculumAssessment {
   curriculum_id: number;
   activity_id: number;
   principal_id: number;
-  questions: Question[];
+  questions?: Question[];
 }
 
 export interface Answer {
@@ -130,7 +130,7 @@ export interface FacilitatorAssessmentSubmissionsSummary {
   num_ungraded_submissions: number;
 }
 
-export interface ProgramAvailableAssessmentsSummary {
+export interface AssessmentsSummary {
   curriculum_assessment: CurriculumAssessment;
   program_assessment: ProgramAssessment;
   submissions_summary:
@@ -138,7 +138,7 @@ export interface ProgramAvailableAssessmentsSummary {
     | FacilitatorAssessmentSubmissionsSummary;
 }
 
-export interface AssessmentResponses {
+export interface AssessmentResponse {
   id?: number;
   assessment_id: number;
   submission_id: number;
@@ -157,73 +157,17 @@ export interface AssessmentSubmission {
   score?: number;
   opened_at: string;
   submitted_at?: string;
-  state_id: number;
-  responses?: AssessmentResponses[];
+  responses?: AssessmentResponse[];
 }
 
-export interface ProgramSubmittedAssessments {
+export interface SubmittedAssessment {
   curriculum_assessment: CurriculumAssessment;
   program_assessment: ProgramAssessment;
   submissions: AssessmentSubmission[];
-}
-
-export interface AssessmentSubmission {
-  id?: number;
-  assessment_id: number;
-  principal_id: number;
-  assessment_submission_state: string;
-  score?: number;
-  opened_at: string;
-  submitted_at?: string;
-  responses?: AssessmentResponses[];
-}
-
-export interface ProgramSubmittedAssessments {
-  curriculum_assessment: CurriculumAssessment;
-  program_assessment: ProgramAssessment;
-  submission: AssessmentSubmission;
-}
-export interface AssessmentSubmission {
-  id?: number;
-  assessment_id: number;
-  principal_id: number;
-  assessment_submission_state: string;
-  score?: number;
-  opened_at: string;
-  submitted_at?: string;
-  responses?: AssessmentResponses[];
-}
-
-export interface DraftProgramAssessment {
-  curriculum_assessment: CurriculumAssessment;
-  program_assessment: ProgramAssessment;
-  submission: AssessmentSubmission;
 }
 
 export interface ProgramParticipantCompletionSummary {
   program: Program;
   principal_id: number;
   total_score: number;
-}
-
-export interface ProgramCertificate {
-  completion_summary: ProgramParticipantCompletionSummary;
-}
-
-export interface NewProgramAssessment {
-  curriculum_assessment: CurriculumAssessment;
-  program_assessment: ProgramAssessment;
-}
-
-export interface EditProgramAssessment {
-  curriculum_assessment: CurriculumAssessment;
-  program_assessment: ProgramAssessment;
-}
-
-export interface DeleteProgramAssessment {
-  submission: AssessmentSubmission;
-}
-
-export interface SubmitProgramAssessment {
-  submission: AssessmentSubmission;
 }

--- a/api/src/models.d.ts
+++ b/api/src/models.d.ts
@@ -1,3 +1,5 @@
+import assessmentsRouter from './middleware/assessmentsRouter';
+
 export interface Program {
   id: number;
   title: string;
@@ -71,4 +73,194 @@ export interface ParticipantActivityCompletionStatus {
 export interface ParticipantActivityForProgram {
   program_id: number;
   participant_activities: ParticipantActivityCompletionStatus[];
+}
+
+export interface CurriculumAssessment {
+  id?: number;
+  title: string;
+  description?: string;
+  max_score: number;
+  max_num_submissions: number;
+  time_limit?: number;
+  curriculum_id: number;
+  activity_id: number;
+  principal_id: number;
+  questions: Question[];
+}
+
+export interface Question {
+  assessment_question_id: number;
+  id?: number;
+  assessment_id?: number;
+  title: string;
+  description?: string;
+  question_type: string;
+  answers?: Answer[];
+  correct_answer_id?: number;
+  max_score: number;
+  sort_order: number;
+}
+
+export interface Answer {
+  id?: number;
+  question_id?: number;
+  title: string;
+  description?: string;
+  sort_order: number;
+  correct_answer?: boolean;
+}
+
+export interface AssessmentSubmissionsSummary {
+  principal_id: number;
+  highest_state: string;
+  most_recent_submitted_date: string;
+  total_num_submissions: number;
+  highest_score?: number;
+}
+
+export interface ProgramAssessment {
+  id?: number;
+  program_id: number;
+  assessment_id?: number;
+  available_after: string;
+  due_date: string;
+}
+
+/**
+ * GET /assessments
+ */
+
+export interface FacilitatorAssessmentSubmissionsSummary {
+  num_participants_with_submissions: number;
+  num_program_participants: number;
+  num_ungraded_submissions: number;
+}
+
+export interface ProgramAvailableAssessmentsSummary {
+  curriculum_assessment: CurriculumAssessment;
+  program_assessment: ProgramAssessment;
+  submissions_summary:
+    | AssessmentSubmissionsSummary
+    | FacilitatorAssessmentSubmissionsSummary;
+}
+
+export interface AssessmentResponses {
+  id?: number;
+  assessment_id: number;
+  submission_id: number;
+  question_id: number;
+  answer_id?: number;
+  response?: string;
+  score?: number;
+  grader_response?: string;
+}
+
+export interface AssessmentSubmission {
+  id?: number;
+  assessment_id: number;
+  principal_id: number;
+  assessment_submission_state: string;
+  score?: number;
+  opened_at: string;
+  submitted_at?: string;
+  state_id: number;
+  responses?: AssessmentResponses[];
+}
+
+/**
+ * GET assessments/:assessmentId
+ */
+export interface ProgramSubmittedAssessments {
+  /*(assessment_id: number, program_id: number)*/
+  curriculum_assessment: CurriculumAssessment;
+  program_assessment: ProgramAssessment;
+  submissions: AssessmentSubmission[];
+}
+
+export interface AssessmentSubmission {
+  id?: number;
+  assessment_id: number;
+  principal_id: number;
+  assessment_submission_state: string;
+  score?: number;
+  opened_at: string;
+  submitted_at?: string;
+  responses?: AssessmentResponses[];
+}
+
+/**
+ * GET /assessments/:assessmentId/submission/:submissionId
+ */
+
+export interface ProgramSubmittedAssessments {
+  /*(assessment_id:number, assessment_submission_id:number)*/
+  curriculum_assessment: CurriculumAssessment;
+  program_assessment: ProgramAssessment;
+  submission: AssessmentSubmission;
+}
+export interface AssessmentSubmission {
+  id?: number;
+  assessment_id: number;
+  principal_id: number;
+  assessment_submission_state: string;
+  score?: number;
+  opened_at: string;
+  submitted_at?: string;
+  responses?: AssessmentResponses[];
+}
+
+/**
+ * GET /assessments/:assessmentId/submission/new
+ */
+
+export interface DraftProgramAssessment {
+  /*(assessment_id:number)*/ curriculum_assessment: CurriculumAssessment;
+  program_assessment: ProgramAssessment;
+  submission: AssessmentSubmission;
+}
+
+export interface ProgramParticipantCompletionSummary {
+  program: Program;
+  principal_id: number;
+  total_score: number;
+}
+
+/**
+ * GET /programs/:programId/certificate/:principalId
+ */
+export interface ProgramCertificate {
+  completion_summary: boolean;
+  Program_participant_completion_summary: ProgramParticipantCompletionSummary;
+}
+
+/**
+ * POST assessments
+ */
+
+export interface NewProgramAssessment {
+  curriculum_assessment: CurriculumAssessment;
+  program_assessment: ProgramAssessment;
+}
+/**
+ * PUT assessments/:assessmentId
+ */
+
+export interface EditProgramAssessment {
+  curriculum_assessment: CurriculumAssessment;
+  program_assessment: ProgramAssessment;
+}
+
+/**
+ * DELETE /assessments/:assessmentId
+ */
+export interface DeleteProgramAssessment {
+  /*(assessment_id:number)*/ submission: AssessmentSubmission;
+}
+
+/**
+ * PUT /assessments/:assessmentId/submission/:submissionId
+ */
+export interface SubmitProgramAssessment {
+  /*(AssessmentSubmission assessment_submission)*/
+  submission: AssessmentSubmission;
 }

--- a/api/src/models.d.ts
+++ b/api/src/models.d.ts
@@ -73,9 +73,17 @@ export interface ParticipantActivityForProgram {
   participant_activities: ParticipantActivityCompletionStatus[];
 }
 
+export interface Answer {
+  id?: number;
+  question_id?: number;
+  title: string;
+  description?: string;
+  sort_order: number;
+  correct_answer?: boolean;
+}
+
 export interface Question {
   id?: number;
-  assessment_question_id: number;
   assessment_id?: number;
   title: string;
   description?: string;
@@ -97,15 +105,6 @@ export interface CurriculumAssessment {
   activity_id: number;
   principal_id: number;
   questions?: Question[];
-}
-
-export interface Answer {
-  id?: number;
-  question_id?: number;
-  title: string;
-  description?: string;
-  sort_order: number;
-  correct_answer?: boolean;
 }
 
 export interface AssessmentSubmissionsSummary {

--- a/webapp/src/types/api.d.ts
+++ b/webapp/src/types/api.d.ts
@@ -192,7 +192,7 @@ export interface FacilitatorAssessmentSubmissionsSummary {
   num_ungraded_submissions: number;
 }
 
-export interface AssessmentsSummary {
+export interface AssessmentSummary {
   curriculum_assessment: CurriculumAssessment;
   program_assessment: ProgramAssessment;
   submissions_summary:

--- a/webapp/src/types/api.d.ts
+++ b/webapp/src/types/api.d.ts
@@ -137,8 +137,8 @@ export interface ParticipantActivityForProgram {
 }
 
 export interface Question {
-  assessment_question_id: number;
   id?: number;
+  assessment_question_id: number;
   assessment_id?: number;
   title: string;
   description?: string;
@@ -159,7 +159,7 @@ export interface CurriculumAssessment {
   curriculum_id: number;
   activity_id: number;
   principal_id: number;
-  questions: Question[];
+  questions?: Question[];
 }
 
 export interface Answer {
@@ -193,7 +193,7 @@ export interface FacilitatorAssessmentSubmissionsSummary {
   num_ungraded_submissions: number;
 }
 
-export interface ProgramAvailableAssessmentsSummary {
+export interface AssessmentsSummary {
   curriculum_assessment: CurriculumAssessment;
   program_assessment: ProgramAssessment;
   submissions_summary:
@@ -201,7 +201,7 @@ export interface ProgramAvailableAssessmentsSummary {
     | FacilitatorAssessmentSubmissionsSummary;
 }
 
-export interface AssessmentResponses {
+export interface AssessmentResponse {
   id?: number;
   assessment_id: number;
   submission_id: number;
@@ -220,73 +220,17 @@ export interface AssessmentSubmission {
   score?: number;
   opened_at: string;
   submitted_at?: string;
-  state_id: number;
-  responses?: AssessmentResponses[];
+  responses?: AssessmentResponse[];
 }
 
-export interface ProgramSubmittedAssessments {
+export interface SubmittedAssessment {
   curriculum_assessment: CurriculumAssessment;
   program_assessment: ProgramAssessment;
   submissions: AssessmentSubmission[];
-}
-
-export interface AssessmentSubmission {
-  id?: number;
-  assessment_id: number;
-  principal_id: number;
-  assessment_submission_state: string;
-  score?: number;
-  opened_at: string;
-  submitted_at?: string;
-  responses?: AssessmentResponses[];
-}
-
-export interface ProgramSubmittedAssessments {
-  curriculum_assessment: CurriculumAssessment;
-  program_assessment: ProgramAssessment;
-  submission: AssessmentSubmission;
-}
-export interface AssessmentSubmission {
-  id?: number;
-  assessment_id: number;
-  principal_id: number;
-  assessment_submission_state: string;
-  score?: number;
-  opened_at: string;
-  submitted_at?: string;
-  responses?: AssessmentResponses[];
-}
-
-export interface DraftProgramAssessment {
-  curriculum_assessment: CurriculumAssessment;
-  program_assessment: ProgramAssessment;
-  submission: AssessmentSubmission;
 }
 
 export interface ProgramParticipantCompletionSummary {
   program: Program;
   principal_id: number;
   total_score: number;
-}
-
-export interface ProgramCertificate {
-  completion_summary: ProgramParticipantCompletionSummary;
-}
-
-export interface NewProgramAssessment {
-  curriculum_assessment: CurriculumAssessment;
-  program_assessment: ProgramAssessment;
-}
-
-export interface EditProgramAssessment {
-  curriculum_assessment: CurriculumAssessment;
-  program_assessment: ProgramAssessment;
-}
-
-export interface DeleteProgramAssessment {
-  submission: AssessmentSubmission;
-}
-
-export interface SubmitProgramAssessment {
-  submission: AssessmentSubmission;
 }

--- a/webapp/src/types/api.d.ts
+++ b/webapp/src/types/api.d.ts
@@ -136,7 +136,6 @@ export interface ParticipantActivityForProgram {
   participant_activities: ParticipantActivityCompletionStatus[];
 }
 
-
 export interface Question {
   assessment_question_id: number;
   id?: number;

--- a/webapp/src/types/api.d.ts
+++ b/webapp/src/types/api.d.ts
@@ -135,3 +135,159 @@ export interface ParticipantActivityForProgram {
   program_id: number;
   participant_activities: ParticipantActivityCompletionStatus[];
 }
+
+
+export interface Question {
+  assessment_question_id: number;
+  id?: number;
+  assessment_id?: number;
+  title: string;
+  description?: string;
+  question_type: string;
+  answers?: Answer[];
+  correct_answer_id?: number;
+  max_score: number;
+  sort_order: number;
+}
+
+export interface CurriculumAssessment {
+  id?: number;
+  title: string;
+  description?: string;
+  max_score: number;
+  max_num_submissions: number;
+  time_limit?: number;
+  curriculum_id: number;
+  activity_id: number;
+  principal_id: number;
+  questions: Question[];
+}
+
+export interface Answer {
+  id?: number;
+  question_id?: number;
+  title: string;
+  description?: string;
+  sort_order: number;
+  correct_answer?: boolean;
+}
+
+export interface AssessmentSubmissionsSummary {
+  principal_id: number;
+  highest_state: string;
+  most_recent_submitted_date: string;
+  total_num_submissions: number;
+  highest_score?: number;
+}
+
+export interface ProgramAssessment {
+  id?: number;
+  program_id: number;
+  assessment_id?: number;
+  available_after: string;
+  due_date: string;
+}
+
+export interface FacilitatorAssessmentSubmissionsSummary {
+  num_participants_with_submissions: number;
+  num_program_participants: number;
+  num_ungraded_submissions: number;
+}
+
+export interface ProgramAvailableAssessmentsSummary {
+  curriculum_assessment: CurriculumAssessment;
+  program_assessment: ProgramAssessment;
+  submissions_summary:
+    | AssessmentSubmissionsSummary
+    | FacilitatorAssessmentSubmissionsSummary;
+}
+
+export interface AssessmentResponses {
+  id?: number;
+  assessment_id: number;
+  submission_id: number;
+  question_id: number;
+  answer_id?: number;
+  response?: string;
+  score?: number;
+  grader_response?: string;
+}
+
+export interface AssessmentSubmission {
+  id?: number;
+  assessment_id: number;
+  principal_id: number;
+  assessment_submission_state: string;
+  score?: number;
+  opened_at: string;
+  submitted_at?: string;
+  state_id: number;
+  responses?: AssessmentResponses[];
+}
+
+export interface ProgramSubmittedAssessments {
+  curriculum_assessment: CurriculumAssessment;
+  program_assessment: ProgramAssessment;
+  submissions: AssessmentSubmission[];
+}
+
+export interface AssessmentSubmission {
+  id?: number;
+  assessment_id: number;
+  principal_id: number;
+  assessment_submission_state: string;
+  score?: number;
+  opened_at: string;
+  submitted_at?: string;
+  responses?: AssessmentResponses[];
+}
+
+export interface ProgramSubmittedAssessments {
+  curriculum_assessment: CurriculumAssessment;
+  program_assessment: ProgramAssessment;
+  submission: AssessmentSubmission;
+}
+export interface AssessmentSubmission {
+  id?: number;
+  assessment_id: number;
+  principal_id: number;
+  assessment_submission_state: string;
+  score?: number;
+  opened_at: string;
+  submitted_at?: string;
+  responses?: AssessmentResponses[];
+}
+
+export interface DraftProgramAssessment {
+  curriculum_assessment: CurriculumAssessment;
+  program_assessment: ProgramAssessment;
+  submission: AssessmentSubmission;
+}
+
+export interface ProgramParticipantCompletionSummary {
+  program: Program;
+  principal_id: number;
+  total_score: number;
+}
+
+export interface ProgramCertificate {
+  completion_summary: ProgramParticipantCompletionSummary;
+}
+
+export interface NewProgramAssessment {
+  curriculum_assessment: CurriculumAssessment;
+  program_assessment: ProgramAssessment;
+}
+
+export interface EditProgramAssessment {
+  curriculum_assessment: CurriculumAssessment;
+  program_assessment: ProgramAssessment;
+}
+
+export interface DeleteProgramAssessment {
+  submission: AssessmentSubmission;
+}
+
+export interface SubmitProgramAssessment {
+  submission: AssessmentSubmission;
+}

--- a/webapp/src/types/api.d.ts
+++ b/webapp/src/types/api.d.ts
@@ -136,9 +136,17 @@ export interface ParticipantActivityForProgram {
   participant_activities: ParticipantActivityCompletionStatus[];
 }
 
+export interface Answer {
+  id?: number;
+  question_id?: number;
+  title: string;
+  description?: string;
+  sort_order: number;
+  correct_answer?: boolean;
+}
+
 export interface Question {
   id?: number;
-  assessment_question_id: number;
   assessment_id?: number;
   title: string;
   description?: string;
@@ -160,15 +168,6 @@ export interface CurriculumAssessment {
   activity_id: number;
   principal_id: number;
   questions?: Question[];
-}
-
-export interface Answer {
-  id?: number;
-  question_id?: number;
-  title: string;
-  description?: string;
-  sort_order: number;
-  correct_answer?: boolean;
 }
 
 export interface AssessmentSubmissionsSummary {


### PR DESCRIPTION
## Proposed Changes

Resolves #517 For each route defined in the list of routes that was in #506, the information being sent to the backend and retrieved from the backend is now defined in a structure which allows us to wire up the backend to the frontend.

## Checklist

- [x] Related issue appears at beginning of pull request title with pound sign, and title describes the changes being proposed.
- [x] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] The appropriate label has been chosen for this pull request.
- [x] The correct project has been selected for this pull request.
- [x] All commits in this branch, including merge commits, begin with the issue number and a pound sign.
- [x] Tests have been added, where appropriate; or, no tests are relevant for this pull request.
- [x] This pull request contains UI changes, and screenshots of those UI images appear below; or, this pull request contains no UI changes.
