### PR TITLE
#534 Add assessment type to CurriculumAssessment

### DIFF
--- a/api/src/models.d.ts
+++ b/api/src/models.d.ts
@@ -97,6 +97,7 @@ export interface Question {
 export interface CurriculumAssessment {
   id?: number;
   title: string;
+  assessment_type: string;
   description?: string;
   max_score: number;
   max_num_submissions: number;

--- a/webapp/src/types/api.d.ts
+++ b/webapp/src/types/api.d.ts
@@ -160,6 +160,7 @@ export interface Question {
 export interface CurriculumAssessment {
   id?: number;
   title: string;
+  assessment_type: string;
   description?: string;
   max_score: number;
   max_num_submissions: number;


### PR DESCRIPTION
## Proposed changes

This commit resolves #534 by adding the assessment type as a member of the CurriculumAssessment models for both `api` and `webapp`. This member should be a string, corresponding with the activity type of the associated activity for that curriculum assessment.

## Checklist

- [x] Related issue appears at beginning of pull request title with pound sign, and title describes the changes being proposed.
- [x] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] The appropriate label has been chosen for this pull request.
- [x] The correct project has been selected for this pull request.
- [x] All commits in this branch, including merge commits, begin with the issue number and a pound sign.
- [x] Tests have been added, where appropriate; or, no tests are relevant for this pull request.
- [x] This pull request contains UI changes, and screenshots of those UI images appear below; or, this pull request contains no UI changes.
