### PR TITLE
#538 Add test for assessment submission route

### DIFF
--- a/api/src/middleware/__tests__/assessmentsRouter.ts
+++ b/api/src/middleware/__tests__/assessmentsRouter.ts
@@ -1,6 +1,19 @@
 import { itemEnvelope } from '../responseEnvelope';
-import { createAppAgentForRouter } from '../routerTestUtils';
+import { createAppAgentForRouter, mockPrincipalId } from '../routerTestUtils';
 import assessmentsRouter from '../assessmentsRouter';
+import { getCurriculumAssessmentBasedOnRole } from '../../services/assessmentService';
+import {
+  CurriculumAssessment,
+  ProgramAssessment,
+  AssessmentSubmission,
+  Question,
+  Answer,
+} from '../../models';
+jest.mock('../../services/assessmentService.ts');
+
+const mockGetCurriculumAssesmentBasedOnRole = jest.mocked(
+  getCurriculumAssessmentBasedOnRole
+);
 
 describe('assessmentsRouter', () => {
   const appAgent = createAppAgentForRouter(assessmentsRouter);
@@ -57,18 +70,126 @@ describe('assessmentsRouter', () => {
         });
     });
   });
+  //**participants: CurriculumAssessment (with 'questions' and 'answers' and correct answers (if graded)), ProgramAssessment, and AssessmentSubmission (with 'responses')
+  //facilitator: CurriculumAssessment (with 'questions' and 'answers' and correct answers), ProgramAssessment, and AssessmentSubmission (with 'responses') */
 
   describe('GET /:assessmentId/submissions/:submissionId', () => {
-    it('should return the submission information', done => {
-      const response = {
-        behaviour:
-          'Returns the submission information (metadata, answers, etc)',
+    it('should return the submission information for the subimtted assessment for facilitator', done => {
+      const facilitatorPrincipalId = 3;
+      const participantPrincipalId = 2;
+      const programAssessmentId = 1,
+        submissionId = 1;
+      const curriculumAssessmentId = 1;
+      const curriculumAssessment = {
+        id: curriculumAssessmentId,
+        title: 'Assignment 1: React',
+        description: 'Your assignment for week 1 learning.',
+        max_score: 10,
+        max_num_submissions: 3,
+        time_limit: 120,
+        curriculum_id: 3,
+        activity_id: 97,
+        principal_id: facilitatorPrincipalId,
+        questions: [
+          {
+            id: 1,
+            assessment_id: curriculumAssessmentId,
+            title: 'What is React?',
+            description: '',
+            question_type: 'single choice',
+            answers: [
+              {
+                id: 1,
+                question_id: 1,
+                title: 'A relational database management system',
+                description: '',
+                sort_order: 1,
+                correct_answer: true,
+              },
+            ],
+            correct_answer_id: 1,
+            max_score: 1,
+            sort_order: 1,
+          },
+        ],
       };
+      const programAssessment = {
+        id: programAssessmentId,
+        program_id: 1,
+        assessment_id: curriculumAssessmentId,
+        available_after: '2023-02-06',
+        due_date: '2023-02-10',
+      };
+
+      const assessmentSubmission = {
+        id: 2,
+        submission_id: 2,
+        assessment_id: programAssessmentId,
+        principal_id: participantPrincipalId,
+        assessment_submission_state: 'Graded',
+        score: 10,
+        opened_at: '2023-02-09 12:00:00',
+        submitted_at: '2023-02-09 13:23:45',
+        responses: [
+          {
+            id: 1,
+            answer_id: 4,
+            assessment_id: 1,
+            submission_id: 2,
+            question_id: 1,
+            score: 1,
+          },
+        ],
+      };
+      const response: {
+        curriculum_assessment: CurriculumAssessment;
+        program_assessment: ProgramAssessment;
+        assessment_submission: AssessmentSubmission;
+      } = {
+        curriculum_assessment: curriculumAssessment,
+        program_assessment: programAssessment,
+        assessment_submission: assessmentSubmission,
+      };
+
+      mockGetCurriculumAssesmentBasedOnRole.mockResolvedValue(response);
+      mockPrincipalId(facilitatorPrincipalId);
       appAgent
-        .get(`/${exampleAssessmentId}/submissions/${exampleSubmissionId}`)
+        .get(`/${programAssessmentId}/submissions/${submissionId}`)
+
         .expect(200, itemEnvelope(response), err => {
+          expect(mockGetCurriculumAssesmentBasedOnRole).toHaveBeenCalledWith(
+            facilitatorPrincipalId,
+            programAssessmentId,
+            submissionId
+          );
+
           done(err);
         });
+    });
+    it('should respond with a bad request error if given an invalid assessment id', done => {
+      const assessmentId = 'test',
+        submissionId = 1;
+
+      appAgent
+        .get(`/${assessmentId}/submissions/${submissionId}`)
+        .expect(400, done);
+    });
+    it('should respond with a bad request error if given an invalid submission id ', done => {
+      const assessmentId = 1,
+        submissionId = 'test';
+
+      appAgent
+        .get(`/${assessmentId}/submissions/${submissionId}`)
+        .expect(400, done);
+    });
+
+    it('should respond with an internal server error if an error', done => {
+      const assessmentId = 1,
+        submissionId = 1;
+      mockGetCurriculumAssesmentBasedOnRole.mockRejectedValue(new Error());
+      appAgent
+        .get(`/${assessmentId}/submissions/${submissionId}`)
+        .expect(500, done);
     });
   });
 

--- a/api/src/middleware/__tests__/assessmentsRouter.ts
+++ b/api/src/middleware/__tests__/assessmentsRouter.ts
@@ -2,7 +2,6 @@ import { itemEnvelope, errorEnvelope } from '../responseEnvelope';
 import { createAppAgentForRouter, mockPrincipalId } from '../routerTestUtils';
 import assessmentsRouter from '../assessmentsRouter';
 import {
-  getCurriculumAssessmentBasedOnRole,
   getProgramIdByProgramAssessmentId,
   findRoleInProgram,
   programAssessmentById,
@@ -14,9 +13,6 @@ import { AssessmentSubmission, AssessmentWithSubmissions } from '../../models';
 
 jest.mock('../../services/assessmentService.ts');
 
-const mockGetCurriculumAssesmentBasedOnRole = jest.mocked(
-  getCurriculumAssessmentBasedOnRole
-);
 const mokeGetProgramIdByProgramAssessmentId = jest.mocked(
   getProgramIdByProgramAssessmentId
 );
@@ -157,26 +153,18 @@ describe('assessmentsRouter', () => {
         submissions: assessmentSubmission,
       };
 
-      mockGetCurriculumAssesmentBasedOnRole.mockResolvedValue(response);
       mokeGetProgramIdByProgramAssessmentId.mockResolvedValue([
         { program_id: programAssessment.program_id },
       ]);
       mokeFindRoleInProgram.mockResolvedValue({ title: 'facilitator' });
       mokeProgramAssessmentById.mockResolvedValue([programAssessment]);
       mokeGetCurriculumAssessmentById.mockResolvedValue(curriculumAssessment);
-      mokeSubmissionDetails.mockResolvedValue(
-        assessmentSubmission[0].responses
-      );
+      mokeSubmissionDetails.mockResolvedValue(assessmentSubmission);
       mockPrincipalId(facilitatorPrincipalId);
       appAgent
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
 
         .expect(200, itemEnvelope(response), err => {
-          expect(mockGetCurriculumAssesmentBasedOnRole).toHaveBeenCalledWith(
-            facilitatorPrincipalId,
-            programAssessmentId,
-            submissionId
-          );
           expect(mokeProgramAssessmentById).toHaveBeenCalledWith(
             programAssessmentId
           );
@@ -201,8 +189,8 @@ describe('assessmentsRouter', () => {
     it('should show a participant their submission information for an in-progress assessment without including the correct answers', done => {
       const facilitatorPrincipalId = 3;
       const participantPrincipalId = 2;
-      const programAssessmentId = 1,
-        submissionId = 1;
+      const programAssessmentId = 1;
+      const submissionId = 1;
       const curriculumAssessmentId = 1;
       const curriculumAssessment = {
         id: curriculumAssessmentId,
@@ -268,26 +256,18 @@ describe('assessmentsRouter', () => {
         submissions: assessmentSubmission,
       };
 
-      mockGetCurriculumAssesmentBasedOnRole.mockResolvedValue(response);
       mokeGetProgramIdByProgramAssessmentId.mockResolvedValue([
         { program_id: programAssessment.program_id },
       ]);
       mokeFindRoleInProgram.mockResolvedValue({ title: 'participant' });
       mokeProgramAssessmentById.mockResolvedValue([programAssessment]);
       mokeGetCurriculumAssessmentById.mockResolvedValue(curriculumAssessment);
-      mokeSubmissionDetails.mockResolvedValue(
-        assessmentSubmission[0].responses
-      );
+      mokeSubmissionDetails.mockResolvedValue(assessmentSubmission);
       mockPrincipalId(participantPrincipalId);
       appAgent
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
 
         .expect(200, itemEnvelope(response), err => {
-          expect(mockGetCurriculumAssesmentBasedOnRole).toHaveBeenCalledWith(
-            facilitatorPrincipalId,
-            programAssessmentId,
-            submissionId
-          );
           expect(mokeProgramAssessmentById).toHaveBeenCalledWith(
             programAssessmentId
           );
@@ -379,26 +359,18 @@ describe('assessmentsRouter', () => {
         submissions: assessmentSubmission,
       };
 
-      mockGetCurriculumAssesmentBasedOnRole.mockResolvedValue(response);
       mokeGetProgramIdByProgramAssessmentId.mockResolvedValue([
         { program_id: programAssessment.program_id },
       ]);
       mokeFindRoleInProgram.mockResolvedValue({ title: 'participant' });
       mokeProgramAssessmentById.mockResolvedValue([programAssessment]);
       mokeGetCurriculumAssessmentById.mockResolvedValue(curriculumAssessment);
-      mokeSubmissionDetails.mockResolvedValue(
-        assessmentSubmission[0].responses
-      );
+      mokeSubmissionDetails.mockResolvedValue(assessmentSubmission);
       mockPrincipalId(participantPrincipalId);
       appAgent
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
 
         .expect(200, itemEnvelope(response), err => {
-          expect(mockGetCurriculumAssesmentBasedOnRole).toHaveBeenCalledWith(
-            facilitatorPrincipalId,
-            programAssessmentId,
-            submissionId
-          );
           expect(mokeProgramAssessmentById).toHaveBeenCalledWith(
             programAssessmentId
           );
@@ -498,11 +470,6 @@ describe('assessmentsRouter', () => {
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
 
         .expect(200, itemEnvelope(response), err => {
-          expect(mockGetCurriculumAssesmentBasedOnRole).toHaveBeenCalledWith(
-            facilitatorPrincipalId,
-            programAssessmentId,
-            submissionId
-          );
           expect(mokeProgramAssessmentById).toHaveBeenCalledWith(
             programAssessmentId
           );
@@ -525,11 +492,11 @@ describe('assessmentsRouter', () => {
         });
     });
     it('should respond with a bad request error if given an invalid assessment id', done => {
-      const assessmentId = 'test',
+      const programAssessmentId = 'test',
         submissionId = 1;
 
       appAgent
-        .get(`/${assessmentId}/submissions/${submissionId}`)
+        .get(`/${programAssessmentId}/submissions/${submissionId}`)
         .expect(400, done);
     });
     it('should respond with a NotFoundError if the assessment ID was not found in the database', done => {
@@ -580,52 +547,10 @@ describe('assessmentsRouter', () => {
     });
 
     it('should respond with an UnauthorizedError if the logged-in principal ID is not the same as the principal ID of the submission ID and is not the principal ID of the program facilitator', done => {
-      const facilitatorPrincipalId = 3;
       const loggedPrincipalId = 4;
       const participantPrincipalId = 2;
       const programAssessmentId = 1;
       const submissionId = 1;
-      const curriculumAssessmentId = 1;
-      const curriculumAssessment = {
-        id: curriculumAssessmentId,
-        title: 'Assignment 1: React',
-        description: 'Your assignment for week 1 learning.',
-        max_score: 10,
-        max_num_submissions: 1,
-        time_limit: 120,
-        curriculum_id: 3,
-        activity_id: 97,
-        principal_id: facilitatorPrincipalId,
-        questions: [
-          {
-            id: 1,
-            assessment_id: curriculumAssessmentId,
-            title: 'What is React?',
-            description: '',
-            question_type: 'single choice',
-            answers: [
-              {
-                id: 1,
-                question_id: 1,
-                title: 'A relational database management system',
-                description: '',
-                sort_order: 1,
-                correct_answer: true,
-              },
-            ],
-            correct_answer_id: 1,
-            max_score: 1,
-            sort_order: 1,
-          },
-        ],
-      };
-      const programAssessment = {
-        id: programAssessmentId,
-        program_id: 1,
-        assessment_id: curriculumAssessmentId,
-        available_after: '2023-02-06',
-        due_date: '2023-02-10',
-      };
 
       const assessmentSubmission: AssessmentSubmission[] = [
         {
@@ -646,34 +571,27 @@ describe('assessmentsRouter', () => {
           ],
         },
       ];
-      const response: AssessmentWithSubmissions = {
-        curriculum_assessment: curriculumAssessment,
-        program_assessment: programAssessment,
-        submissions: assessmentSubmission,
-      };
 
-      mockGetCurriculumAssesmentBasedOnRole.mockResolvedValue(response);
+      mokeSubmissionDetails.mockResolvedValue(assessmentSubmission);
 
       mockPrincipalId(loggedPrincipalId);
       appAgent
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
         .expect(401, errorEnvelope('Unauthorized user.'), err => {
-          expect(mockGetCurriculumAssesmentBasedOnRole).toHaveBeenCalledWith(
-            facilitatorPrincipalId,
+          expect(mokeSubmissionDetails).toHaveBeenCalledWith(
             programAssessmentId,
-            submissionId
+            submissionId,
+            true
           );
-          // expect(mockPrincipalId).toHaveBeenCalledWith(
-          //   participantPrincipalId
-          // );
           done(err);
         });
     });
     it('should respond with an internal server error if a database error occurs', done => {
       const programAssessmentId = 1,
         submissionId = 1;
+      mokeSubmissionDetails.mockRejectedValue(new Error());
+      appAgent;
 
-      mockGetCurriculumAssesmentBasedOnRole.mockRejectedValue(new Error());
       appAgent
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
         .expect(500, done);

--- a/api/src/middleware/__tests__/assessmentsRouter.ts
+++ b/api/src/middleware/__tests__/assessmentsRouter.ts
@@ -9,7 +9,7 @@ import {
   submissionDetails,
 } from '../../services/assessmentService';
 
-import { AssessmentSubmission, AssessmentWithSubmissions } from '../../models';
+import { SubmittedAssessment } from '../../models';
 
 jest.mock('../../services/assessmentService.ts');
 
@@ -128,29 +128,28 @@ describe('assessmentsRouter', () => {
         due_date: '2023-02-10',
       };
 
-      const assessmentSubmission: AssessmentSubmission[] = [
-        {
-          id: 2,
-          assessment_id: programAssessmentId,
-          principal_id: participantPrincipalId,
-          assessment_submission_state: 'Submitted',
-          opened_at: '2023-02-09 12:00:00',
-          submitted_at: '2023-02-09 13:23:45',
-          responses: [
-            {
-              id: 1,
-              answer_id: 1,
-              assessment_id: 1,
-              submission_id: 2,
-              question_id: 1,
-            },
-          ],
-        },
-      ];
-      const response: AssessmentWithSubmissions = {
+      const assessmentSubmission = {
+        id: 2,
+        assessment_id: programAssessmentId,
+        principal_id: participantPrincipalId,
+        assessment_submission_state: 'Submitted',
+        opened_at: '2023-02-09 12:00:00',
+        submitted_at: '2023-02-09 13:23:45',
+        responses: [
+          {
+            id: 1,
+            answer_id: 1,
+            assessment_id: 1,
+            submission_id: 2,
+            question_id: 1,
+          },
+        ],
+      };
+
+      const response: SubmittedAssessment = {
         curriculum_assessment: curriculumAssessment,
         program_assessment: programAssessment,
-        submissions: assessmentSubmission,
+        submission: assessmentSubmission,
       };
 
       mockGetProgramIdByProgramAssessmentId.mockResolvedValue([
@@ -159,7 +158,7 @@ describe('assessmentsRouter', () => {
       mockFindRoleInProgram.mockResolvedValue({ title: 'facilitator' });
       mockProgramAssessmentById.mockResolvedValue([programAssessment]);
       mockGetCurriculumAssessmentById.mockResolvedValue(curriculumAssessment);
-      mockSubmissionDetails.mockResolvedValue(assessmentSubmission);
+      mockSubmissionDetails.mockResolvedValue([assessmentSubmission]);
       mockPrincipalId(facilitatorPrincipalId);
       appAgent
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
@@ -186,6 +185,7 @@ describe('assessmentsRouter', () => {
           done(err);
         });
     });
+
     it('should show a participant their submission information for an in-progress assessment without including the correct answers', done => {
       const facilitatorPrincipalId = 3;
       const participantPrincipalId = 2;
@@ -231,29 +231,27 @@ describe('assessmentsRouter', () => {
         due_date: '2023-02-10',
       };
 
-      const assessmentSubmission: AssessmentSubmission[] = [
-        {
-          id: 2,
-          assessment_id: programAssessmentId,
-          principal_id: participantPrincipalId,
-          assessment_submission_state: 'In Progress',
-          opened_at: '2023-02-09 12:00:00',
-          submitted_at: '2023-02-09 13:23:45',
-          responses: [
-            {
-              id: 1,
-              answer_id: 1,
-              assessment_id: 1,
-              submission_id: 2,
-              question_id: 1,
-            },
-          ],
-        },
-      ];
-      const response: AssessmentWithSubmissions = {
+      const assessmentSubmission = {
+        id: 2,
+        assessment_id: programAssessmentId,
+        principal_id: participantPrincipalId,
+        assessment_submission_state: 'In Progress',
+        opened_at: '2023-02-09 12:00:00',
+        submitted_at: '2023-02-09 13:23:45',
+        responses: [
+          {
+            id: 1,
+            answer_id: 1,
+            assessment_id: 1,
+            submission_id: 2,
+            question_id: 1,
+          },
+        ],
+      };
+      const response: SubmittedAssessment = {
         curriculum_assessment: curriculumAssessment,
         program_assessment: programAssessment,
-        submissions: assessmentSubmission,
+        submission: assessmentSubmission,
       };
 
       mockGetProgramIdByProgramAssessmentId.mockResolvedValue([
@@ -262,7 +260,7 @@ describe('assessmentsRouter', () => {
       mockFindRoleInProgram.mockResolvedValue({ title: 'participant' });
       mockProgramAssessmentById.mockResolvedValue([programAssessment]);
       mockGetCurriculumAssessmentById.mockResolvedValue(curriculumAssessment);
-      mockSubmissionDetails.mockResolvedValue(assessmentSubmission);
+      mockSubmissionDetails.mockResolvedValue([assessmentSubmission]);
       mockPrincipalId(participantPrincipalId);
       appAgent
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
@@ -289,6 +287,7 @@ describe('assessmentsRouter', () => {
           done(err);
         });
     });
+
     it('should show a participant their submission information for an ungraded submitted assessment without including the correct answers', done => {
       const facilitatorPrincipalId = 3;
       const participantPrincipalId = 2;
@@ -334,29 +333,27 @@ describe('assessmentsRouter', () => {
         due_date: '2023-02-10',
       };
 
-      const assessmentSubmission: AssessmentSubmission[] = [
-        {
-          id: 2,
-          assessment_id: programAssessmentId,
-          principal_id: participantPrincipalId,
-          assessment_submission_state: 'Submitted',
-          opened_at: '2023-02-09 12:00:00',
-          submitted_at: '2023-02-09 13:23:45',
-          responses: [
-            {
-              id: 1,
-              answer_id: 1,
-              assessment_id: 1,
-              submission_id: 2,
-              question_id: 1,
-            },
-          ],
-        },
-      ];
-      const response: AssessmentWithSubmissions = {
+      const assessmentSubmission = {
+        id: 2,
+        assessment_id: programAssessmentId,
+        principal_id: participantPrincipalId,
+        assessment_submission_state: 'Submitted',
+        opened_at: '2023-02-09 12:00:00',
+        submitted_at: '2023-02-09 13:23:45',
+        responses: [
+          {
+            id: 1,
+            answer_id: 1,
+            assessment_id: 1,
+            submission_id: 2,
+            question_id: 1,
+          },
+        ],
+      };
+      const response: SubmittedAssessment = {
         curriculum_assessment: curriculumAssessment,
         program_assessment: programAssessment,
-        submissions: assessmentSubmission,
+        submission: assessmentSubmission,
       };
 
       mockGetProgramIdByProgramAssessmentId.mockResolvedValue([
@@ -365,7 +362,7 @@ describe('assessmentsRouter', () => {
       mockFindRoleInProgram.mockResolvedValue({ title: 'participant' });
       mockProgramAssessmentById.mockResolvedValue([programAssessment]);
       mockGetCurriculumAssessmentById.mockResolvedValue(curriculumAssessment);
-      mockSubmissionDetails.mockResolvedValue(assessmentSubmission);
+      mockSubmissionDetails.mockResolvedValue([assessmentSubmission]);
       mockPrincipalId(participantPrincipalId);
       appAgent
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
@@ -392,6 +389,7 @@ describe('assessmentsRouter', () => {
           done(err);
         });
     });
+
     it('should show a participant their submission information for a graded submitted assessment including the correct answers', done => {
       const facilitatorPrincipalId = 3;
       const participantPrincipalId = 2;
@@ -439,30 +437,28 @@ describe('assessmentsRouter', () => {
         due_date: '2023-02-10',
       };
 
-      const assessmentSubmission: AssessmentSubmission[] = [
-        {
-          id: 2,
-          assessment_id: programAssessmentId,
-          principal_id: participantPrincipalId,
-          assessment_submission_state: 'graded',
-          score: 1,
-          opened_at: '2023-02-09 12:00:00',
-          submitted_at: '2023-02-09 13:23:45',
-          responses: [
-            {
-              id: 1,
-              answer_id: 1,
-              assessment_id: 1,
-              submission_id: 2,
-              question_id: 1,
-            },
-          ],
-        },
-      ];
-      const response: AssessmentWithSubmissions = {
+      const assessmentSubmission = {
+        id: 2,
+        assessment_id: programAssessmentId,
+        principal_id: participantPrincipalId,
+        assessment_submission_state: 'graded',
+        score: 1,
+        opened_at: '2023-02-09 12:00:00',
+        submitted_at: '2023-02-09 13:23:45',
+        responses: [
+          {
+            id: 1,
+            answer_id: 1,
+            assessment_id: 1,
+            submission_id: 2,
+            question_id: 1,
+          },
+        ],
+      };
+      const response: SubmittedAssessment = {
         curriculum_assessment: curriculumAssessment,
         program_assessment: programAssessment,
-        submissions: assessmentSubmission,
+        submission: assessmentSubmission,
       };
 
       mockPrincipalId(participantPrincipalId);
@@ -491,6 +487,7 @@ describe('assessmentsRouter', () => {
           done(err);
         });
     });
+
     it('should respond with a bad request error if given an invalid assessment id', done => {
       const programAssessmentId = 'test',
         submissionId = 1;
@@ -499,6 +496,7 @@ describe('assessmentsRouter', () => {
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
         .expect(400, done);
     });
+
     it('should respond with a NotFoundError if the assessment ID was not found in the database', done => {
       const programAssessmentId = 7,
         submissionId = 1;
@@ -517,6 +515,7 @@ describe('assessmentsRouter', () => {
           }
         );
     });
+
     it('should respond with a bad request error if given an invalid submission id ', done => {
       const programAssessmentId = 1,
         submissionId = 'test';
@@ -525,6 +524,7 @@ describe('assessmentsRouter', () => {
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
         .expect(400, done);
     });
+
     it('should respond with a NotFoundError if the submission ID was not found in the database ', done => {
       const programAssessmentId = 1,
         submissionId = 8;
@@ -552,27 +552,25 @@ describe('assessmentsRouter', () => {
       const programAssessmentId = 1;
       const submissionId = 1;
 
-      const assessmentSubmission: AssessmentSubmission[] = [
-        {
-          id: 2,
-          assessment_id: programAssessmentId,
-          principal_id: participantPrincipalId,
-          assessment_submission_state: 'Submitted',
-          opened_at: '2023-02-09 12:00:00',
-          submitted_at: '2023-02-09 13:23:45',
-          responses: [
-            {
-              id: 1,
-              answer_id: 1,
-              assessment_id: 1,
-              submission_id: 2,
-              question_id: 1,
-            },
-          ],
-        },
-      ];
+      const assessmentSubmission = {
+        id: 2,
+        assessment_id: programAssessmentId,
+        principal_id: participantPrincipalId,
+        assessment_submission_state: 'Submitted',
+        opened_at: '2023-02-09 12:00:00',
+        submitted_at: '2023-02-09 13:23:45',
+        responses: [
+          {
+            id: 1,
+            answer_id: 1,
+            assessment_id: 1,
+            submission_id: 2,
+            question_id: 1,
+          },
+        ],
+      };
 
-      mockSubmissionDetails.mockResolvedValue(assessmentSubmission);
+      mockSubmissionDetails.mockResolvedValue([assessmentSubmission]);
 
       mockPrincipalId(loggedPrincipalId);
       appAgent
@@ -586,6 +584,7 @@ describe('assessmentsRouter', () => {
           done(err);
         });
     });
+
     it('should respond with an internal server error if a database error occurs', done => {
       const programAssessmentId = 1,
         submissionId = 1;
@@ -596,27 +595,27 @@ describe('assessmentsRouter', () => {
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
         .expect(500, done);
     });
+  });
 
-    describe('PUT /:assessmentId/submissions/:submissionId', () => {
-      it('should update the state of a submission', done => {
-        const response = { behaviour: 'Updates the state of a submission' };
-        appAgent
-          .put(`/${exampleAssessmentId}/submissions/${exampleSubmissionId}`)
-          .expect(200, itemEnvelope(response), err => {
-            done(err);
-          });
-      });
+  describe('PUT /:assessmentId/submissions/:submissionId', () => {
+    it('should update the state of a submission', done => {
+      const response = { behaviour: 'Updates the state of a submission' };
+      appAgent
+        .put(`/${exampleAssessmentId}/submissions/${exampleSubmissionId}`)
+        .expect(200, itemEnvelope(response), err => {
+          done(err);
+        });
     });
+  });
 
-    describe('GET /:assessmentId/submissions/new', () => {
-      it('should create a new draft submission', done => {
-        const response = { behaviour: 'Creates a new draft submission' };
-        appAgent
-          .get(`/${exampleAssessmentId}/submissions/new`)
-          .expect(200, itemEnvelope(response), err => {
-            done(err);
-          });
-      });
+  describe('GET /:assessmentId/submissions/new', () => {
+    it('should create a new draft submission', done => {
+      const response = { behaviour: 'Creates a new draft submission' };
+      appAgent
+        .get(`/${exampleAssessmentId}/submissions/new`)
+        .expect(200, itemEnvelope(response), err => {
+          done(err);
+        });
     });
   });
 });

--- a/api/src/middleware/__tests__/assessmentsRouter.ts
+++ b/api/src/middleware/__tests__/assessmentsRouter.ts
@@ -13,15 +13,15 @@ import { AssessmentSubmission, AssessmentWithSubmissions } from '../../models';
 
 jest.mock('../../services/assessmentService.ts');
 
-const mokeGetProgramIdByProgramAssessmentId = jest.mocked(
+const mockGetProgramIdByProgramAssessmentId = jest.mocked(
   getProgramIdByProgramAssessmentId
 );
-const mokeFindRoleInProgram = jest.mocked(findRoleInProgram);
-const mokeProgramAssessmentById = jest.mocked(programAssessmentById);
-const mokeGetCurriculumAssessmentById = jest.mocked(
+const mockFindRoleInProgram = jest.mocked(findRoleInProgram);
+const mockProgramAssessmentById = jest.mocked(programAssessmentById);
+const mockGetCurriculumAssessmentById = jest.mocked(
   getCurriculumAssessmentById
 );
-const mokeSubmissionDetails = jest.mocked(submissionDetails);
+const mockSubmissionDetails = jest.mocked(submissionDetails);
 
 describe('assessmentsRouter', () => {
   const appAgent = createAppAgentForRouter(assessmentsRouter);
@@ -153,32 +153,32 @@ describe('assessmentsRouter', () => {
         submissions: assessmentSubmission,
       };
 
-      mokeGetProgramIdByProgramAssessmentId.mockResolvedValue([
+      mockGetProgramIdByProgramAssessmentId.mockResolvedValue([
         { program_id: programAssessment.program_id },
       ]);
-      mokeFindRoleInProgram.mockResolvedValue({ title: 'facilitator' });
-      mokeProgramAssessmentById.mockResolvedValue([programAssessment]);
-      mokeGetCurriculumAssessmentById.mockResolvedValue(curriculumAssessment);
-      mokeSubmissionDetails.mockResolvedValue(assessmentSubmission);
+      mockFindRoleInProgram.mockResolvedValue({ title: 'facilitator' });
+      mockProgramAssessmentById.mockResolvedValue([programAssessment]);
+      mockGetCurriculumAssessmentById.mockResolvedValue(curriculumAssessment);
+      mockSubmissionDetails.mockResolvedValue(assessmentSubmission);
       mockPrincipalId(facilitatorPrincipalId);
       appAgent
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
 
         .expect(200, itemEnvelope(response), err => {
-          expect(mokeProgramAssessmentById).toHaveBeenCalledWith(
+          expect(mockProgramAssessmentById).toHaveBeenCalledWith(
             programAssessmentId
           );
-          expect(mokeGetCurriculumAssessmentById).toHaveBeenCalledWith(
+          expect(mockGetCurriculumAssessmentById).toHaveBeenCalledWith(
             programAssessmentId,
             true,
             true
           );
 
-          expect(mokeFindRoleInProgram).toHaveBeenCalledWith(
+          expect(mockFindRoleInProgram).toHaveBeenCalledWith(
             facilitatorPrincipalId,
             programAssessment.program_id
           );
-          expect(mokeSubmissionDetails).toHaveBeenCalledWith(
+          expect(mockSubmissionDetails).toHaveBeenCalledWith(
             programAssessmentId,
             submissionId,
             true
@@ -256,32 +256,32 @@ describe('assessmentsRouter', () => {
         submissions: assessmentSubmission,
       };
 
-      mokeGetProgramIdByProgramAssessmentId.mockResolvedValue([
+      mockGetProgramIdByProgramAssessmentId.mockResolvedValue([
         { program_id: programAssessment.program_id },
       ]);
-      mokeFindRoleInProgram.mockResolvedValue({ title: 'participant' });
-      mokeProgramAssessmentById.mockResolvedValue([programAssessment]);
-      mokeGetCurriculumAssessmentById.mockResolvedValue(curriculumAssessment);
-      mokeSubmissionDetails.mockResolvedValue(assessmentSubmission);
+      mockFindRoleInProgram.mockResolvedValue({ title: 'participant' });
+      mockProgramAssessmentById.mockResolvedValue([programAssessment]);
+      mockGetCurriculumAssessmentById.mockResolvedValue(curriculumAssessment);
+      mockSubmissionDetails.mockResolvedValue(assessmentSubmission);
       mockPrincipalId(participantPrincipalId);
       appAgent
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
 
         .expect(200, itemEnvelope(response), err => {
-          expect(mokeProgramAssessmentById).toHaveBeenCalledWith(
+          expect(mockProgramAssessmentById).toHaveBeenCalledWith(
             programAssessmentId
           );
-          expect(mokeGetCurriculumAssessmentById).toHaveBeenCalledWith(
+          expect(mockGetCurriculumAssessmentById).toHaveBeenCalledWith(
             programAssessmentId,
             true,
             false
           );
 
-          expect(mokeFindRoleInProgram).toHaveBeenCalledWith(
+          expect(mockFindRoleInProgram).toHaveBeenCalledWith(
             facilitatorPrincipalId,
             programAssessment.program_id
           );
-          expect(mokeSubmissionDetails).toHaveBeenCalledWith(
+          expect(mockSubmissionDetails).toHaveBeenCalledWith(
             programAssessmentId,
             submissionId,
             true
@@ -359,32 +359,32 @@ describe('assessmentsRouter', () => {
         submissions: assessmentSubmission,
       };
 
-      mokeGetProgramIdByProgramAssessmentId.mockResolvedValue([
+      mockGetProgramIdByProgramAssessmentId.mockResolvedValue([
         { program_id: programAssessment.program_id },
       ]);
-      mokeFindRoleInProgram.mockResolvedValue({ title: 'participant' });
-      mokeProgramAssessmentById.mockResolvedValue([programAssessment]);
-      mokeGetCurriculumAssessmentById.mockResolvedValue(curriculumAssessment);
-      mokeSubmissionDetails.mockResolvedValue(assessmentSubmission);
+      mockFindRoleInProgram.mockResolvedValue({ title: 'participant' });
+      mockProgramAssessmentById.mockResolvedValue([programAssessment]);
+      mockGetCurriculumAssessmentById.mockResolvedValue(curriculumAssessment);
+      mockSubmissionDetails.mockResolvedValue(assessmentSubmission);
       mockPrincipalId(participantPrincipalId);
       appAgent
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
 
         .expect(200, itemEnvelope(response), err => {
-          expect(mokeProgramAssessmentById).toHaveBeenCalledWith(
+          expect(mockProgramAssessmentById).toHaveBeenCalledWith(
             programAssessmentId
           );
-          expect(mokeGetCurriculumAssessmentById).toHaveBeenCalledWith(
+          expect(mockGetCurriculumAssessmentById).toHaveBeenCalledWith(
             programAssessmentId,
             true,
             false
           );
 
-          expect(mokeFindRoleInProgram).toHaveBeenCalledWith(
+          expect(mockFindRoleInProgram).toHaveBeenCalledWith(
             facilitatorPrincipalId,
             programAssessment.program_id
           );
-          expect(mokeSubmissionDetails).toHaveBeenCalledWith(
+          expect(mockSubmissionDetails).toHaveBeenCalledWith(
             programAssessmentId,
             submissionId,
             true
@@ -470,20 +470,20 @@ describe('assessmentsRouter', () => {
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
 
         .expect(200, itemEnvelope(response), err => {
-          expect(mokeProgramAssessmentById).toHaveBeenCalledWith(
+          expect(mockProgramAssessmentById).toHaveBeenCalledWith(
             programAssessmentId
           );
-          expect(mokeGetCurriculumAssessmentById).toHaveBeenCalledWith(
+          expect(mockGetCurriculumAssessmentById).toHaveBeenCalledWith(
             programAssessmentId,
             true,
             true
           );
 
-          expect(mokeFindRoleInProgram).toHaveBeenCalledWith(
+          expect(mockFindRoleInProgram).toHaveBeenCalledWith(
             facilitatorPrincipalId,
             programAssessment.program_id
           );
-          expect(mokeSubmissionDetails).toHaveBeenCalledWith(
+          expect(mockSubmissionDetails).toHaveBeenCalledWith(
             programAssessmentId,
             submissionId,
             true
@@ -503,14 +503,14 @@ describe('assessmentsRouter', () => {
       const programAssessmentId = 7,
         submissionId = 1;
 
-      mokeGetProgramIdByProgramAssessmentId.mockResolvedValue([]);
+      mockGetProgramIdByProgramAssessmentId.mockResolvedValue([]);
       appAgent
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
         .expect(
           404,
           errorEnvelope('The requested resource does not exist.'),
           err => {
-            expect(mokeGetProgramIdByProgramAssessmentId).toHaveBeenCalledWith(
+            expect(mockGetProgramIdByProgramAssessmentId).toHaveBeenCalledWith(
               programAssessmentId
             );
             done(err);
@@ -529,14 +529,14 @@ describe('assessmentsRouter', () => {
       const programAssessmentId = 1,
         submissionId = 8;
 
-      mokeSubmissionDetails.mockResolvedValue([]);
+      mockSubmissionDetails.mockResolvedValue([]);
       appAgent
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
         .expect(
           404,
           errorEnvelope('The requested resource does not exist.'),
           err => {
-            expect(mokeSubmissionDetails).toHaveBeenCalledWith(
+            expect(mockSubmissionDetails).toHaveBeenCalledWith(
               programAssessmentId,
               submissionId,
               true
@@ -572,13 +572,13 @@ describe('assessmentsRouter', () => {
         },
       ];
 
-      mokeSubmissionDetails.mockResolvedValue(assessmentSubmission);
+      mockSubmissionDetails.mockResolvedValue(assessmentSubmission);
 
       mockPrincipalId(loggedPrincipalId);
       appAgent
         .get(`/${programAssessmentId}/submissions/${submissionId}`)
         .expect(401, errorEnvelope('Unauthorized user.'), err => {
-          expect(mokeSubmissionDetails).toHaveBeenCalledWith(
+          expect(mockSubmissionDetails).toHaveBeenCalledWith(
             programAssessmentId,
             submissionId,
             true
@@ -589,7 +589,7 @@ describe('assessmentsRouter', () => {
     it('should respond with an internal server error if a database error occurs', done => {
       const programAssessmentId = 1,
         submissionId = 1;
-      mokeSubmissionDetails.mockRejectedValue(new Error());
+      mockSubmissionDetails.mockRejectedValue(new Error());
       appAgent;
 
       appAgent

--- a/api/src/models.d.ts
+++ b/api/src/models.d.ts
@@ -159,10 +159,16 @@ export interface AssessmentSubmission {
   responses?: AssessmentResponse[];
 }
 
-export interface SubmittedAssessment {
+export interface AssessmentWithSubmissions {
   curriculum_assessment: CurriculumAssessment;
   program_assessment: ProgramAssessment;
   submissions: AssessmentSubmission[];
+}
+
+export interface SubmittedAssessment {
+  curriculum_assessment: CurriculumAssessment;
+  program_assessment: ProgramAssessment;
+  submission: AssessmentSubmission;
 }
 
 export interface ProgramParticipantCompletionSummary {


### PR DESCRIPTION
## Proposed changes

This pull request resolves #538 by adding tests for retrieving assessment submission.

## Checklist

- [x] Related issue appears at beginning of pull request title with pound sign, and title describes the changes being proposed.
- [x] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] The appropriate label has been chosen for this pull request.
- [x] The correct project has been selected for this pull request.
- [x] All commits in this branch, including merge commits, begin with the issue number and a pound sign.
- [x] Tests have been added, where appropriate; or, no tests are relevant for this pull request.
- [x] This pull request contains UI changes, and screenshots of those UI images appear below; or, this pull request contains no UI changes.
