### PR TITLE
#541 Add test for assessment deletion route

### DIFF
--- a/api/src/middleware/__tests__/assessmentsRouter.ts
+++ b/api/src/middleware/__tests__/assessmentsRouter.ts
@@ -1,7 +1,6 @@
 import { itemEnvelope, errorEnvelope } from '../responseEnvelope';
 import { createAppAgentForRouter, mockPrincipalId } from '../routerTestUtils';
 import assessmentsRouter from '../assessmentsRouter';
-
 jest.mock('../../services/assessmentService.ts');
 
 import {
@@ -68,7 +67,7 @@ describe('assessmentsRouter', () => {
       mockPrincipalId(principalId);
       mockGetProgramIdByProgramAssessmentId.mockResolvedValue([2]);
       mockFindRoleInProgram.mockResolvedValue({ title: 'facilitator' });
-      appAgent.delete(`/1`).expect(204, null, err => {
+      appAgent.delete(`/${assessmentId}`).expect(204, null, err => {
         expect(mockGetProgramIdByProgramAssessmentId).toHaveBeenCalledWith(1);
         expect(mockFindRoleInProgram).toHaveBeenCalledWith(principalId, 2);
         expect(mockDeleteAssessmentById).toHaveBeenCalledWith(1);
@@ -82,7 +81,7 @@ describe('assessmentsRouter', () => {
       mockGetProgramIdByProgramAssessmentId.mockResolvedValue([2]);
       mockFindRoleInProgram.mockResolvedValue({ title: 'participant' });
       appAgent
-        .delete(`/1`)
+        .delete(`/${assessmentId}`)
         .expect(401, errorEnvelope('Unauthorized user.'), err => {
           expect(mockGetProgramIdByProgramAssessmentId).toHaveBeenCalledWith(1);
           expect(mockFindRoleInProgram).toHaveBeenCalledWith(principalId, 2);

--- a/api/src/middleware/__tests__/assessmentsRouter.ts
+++ b/api/src/middleware/__tests__/assessmentsRouter.ts
@@ -1,4 +1,4 @@
-import { itemEnvelope } from '../responseEnvelope';
+import { itemEnvelope, errorEnvelope } from '../responseEnvelope';
 import { createAppAgentForRouter, mockPrincipalId } from '../routerTestUtils';
 import assessmentsRouter from '../assessmentsRouter';
 
@@ -81,11 +81,13 @@ describe('assessmentsRouter', () => {
       mockPrincipalId(principalId);
       mockGetProgramIdByProgramAssessmentId.mockResolvedValue([2]);
       mockFindRoleInProgram.mockResolvedValue({ title: 'participant' });
-      appAgent.delete(`/1`).expect(401, null, err => {
-        expect(mockGetProgramIdByProgramAssessmentId).toHaveBeenCalledWith(1);
-        expect(mockFindRoleInProgram).toHaveBeenCalledWith(principalId, 2);
-        done(err);
-      });
+      appAgent
+        .delete(`/1`)
+        .expect(401, errorEnvelope('Unauthorized user.'), err => {
+          expect(mockGetProgramIdByProgramAssessmentId).toHaveBeenCalledWith(1);
+          expect(mockFindRoleInProgram).toHaveBeenCalledWith(principalId, 2);
+          done(err);
+        });
     });
   });
 

--- a/api/src/middleware/__tests__/assessmentsRouter.ts
+++ b/api/src/middleware/__tests__/assessmentsRouter.ts
@@ -1,6 +1,20 @@
 import { itemEnvelope } from '../responseEnvelope';
-import { createAppAgentForRouter, mockPrincipalId , mockDeleteAssessmentById, mockFindRoleInProgram} from '../routerTestUtils';
+import { createAppAgentForRouter, mockPrincipalId } from '../routerTestUtils';
 import assessmentsRouter from '../assessmentsRouter';
+
+jest.mock('../../services/assessmentService.ts');
+
+import {
+  findRoleInProgram,
+  getProgramIdByProgramAssessmentId,
+  deleteAssessmentById,
+} from '../../services/assessmentService';
+
+const mockFindRoleInProgram = jest.mocked(findRoleInProgram);
+const mockGetProgramIdByProgramAssessmentId = jest.mocked(
+  getProgramIdByProgramAssessmentId
+);
+const mockDeleteAssessmentById = jest.mocked(deleteAssessmentById);
 
 describe('assessmentsRouter', () => {
   const appAgent = createAppAgentForRouter(assessmentsRouter);
@@ -49,66 +63,29 @@ describe('assessmentsRouter', () => {
 
   describe('DELETE /:assessmentId', () => {
     it('should delete a program assessment in the system if logged-in user is facilitator of that program', done => {
-      const principalId =3;
+      const principalId = 3;
       const assessmentId = 1;
       mockPrincipalId(principalId);
-      mockGetProgramIdByProgramAssessmentId
-        .mockResolvedValue(
-        // what should be returned from this function?
-        );
-      mockFindRoleInProgram
-        .mockResolvedValue(
-        // what should be returned from this function?
-        );
-      mockDeleteAssessmentById
-        .mockResolvedValue(
-        // what should be returned from this function?
-        );
-      appAgent.delete(`/${assessmentId}`).expect(204, null, err => {
-        expect(mockGetProgramIdByProgramAssessmentId)
-          .toHaveBeenCalledWith(
-          // what did we call it with?
-          );
-        expect(mockFindRoleInProgram)
-          .toHaveBeenCalledWith(
-          // what did we call it with?
-          );
-        expect(mockDeleteAssessmentById)
-          .toHaveBeenCalledWith(
-          // what did we call it with?
-          );
+      mockGetProgramIdByProgramAssessmentId.mockResolvedValue([2]);
+      mockFindRoleInProgram.mockResolvedValue({ title: 'facilitator' });
+      appAgent.delete(`/1`).expect(204, null, err => {
+        expect(mockGetProgramIdByProgramAssessmentId).toHaveBeenCalledWith(1);
+        expect(mockFindRoleInProgram).toHaveBeenCalledWith(principalId, 2);
+        expect(mockDeleteAssessmentById).toHaveBeenCalledWith(1);
         done(err);
       });
     });
     it('should return an error if logged-in user is not a facilitator of that program', done => {
-      const principalId =3;
+      const principalId = 4;
       const assessmentId = 1;
       mockPrincipalId(principalId);
-      mockGetProgramIdByProgramAssessmentId
-        .mockResolvedValue(
-        // what should be returned from this function?
-        );
-      mockFindRoleInProgram
-        .mockResolvedValue(
-        // what should be returned from this function?
-        );
-      appAgent.delete(`/${assessmentId}`).expect(
-        401,
-        {
-          // what goes here?
-        },
-        err => {
-          expect(mockGetProgramIdByProgramAssessmentId)
-            .toHaveBeenCalledWith(
-            // what did we call it with?
-            );
-          expect(mockFindRoleInProgram)
-            .toHaveBeenCalledWith(
-            // what did we call it with?
-            );
-          done(err);
-        }
-      );
+      mockGetProgramIdByProgramAssessmentId.mockResolvedValue([2]);
+      mockFindRoleInProgram.mockResolvedValue({ title: 'participant' });
+      appAgent.delete(`/1`).expect(401, null, err => {
+        expect(mockGetProgramIdByProgramAssessmentId).toHaveBeenCalledWith(1);
+        expect(mockFindRoleInProgram).toHaveBeenCalledWith(principalId, 2);
+        done(err);
+      });
     });
   });
 

--- a/api/src/middleware/__tests__/assessmentsRouter.ts
+++ b/api/src/middleware/__tests__/assessmentsRouter.ts
@@ -1,5 +1,5 @@
 import { itemEnvelope } from '../responseEnvelope';
-import { createAppAgentForRouter } from '../routerTestUtils';
+import { createAppAgentForRouter, mockPrincipalId , mockDeleteAssessmentById, mockFindRoleInProgram} from '../routerTestUtils';
 import assessmentsRouter from '../assessmentsRouter';
 
 describe('assessmentsRouter', () => {
@@ -48,13 +48,67 @@ describe('assessmentsRouter', () => {
   });
 
   describe('DELETE /:assessmentId', () => {
-    it('should delete an assessment in the system', done => {
-      const response = { behaviour: '“Deletes” an assessment in the system' };
-      appAgent
-        .delete(`/${exampleAssessmentId}`)
-        .expect(200, itemEnvelope(response), err => {
+    it('should delete a program assessment in the system if logged-in user is facilitator of that program', done => {
+      const principalId =3;
+      const assessmentId = 1;
+      mockPrincipalId(principalId);
+      mockGetProgramIdByProgramAssessmentId
+        .mockResolvedValue(
+        // what should be returned from this function?
+        );
+      mockFindRoleInProgram
+        .mockResolvedValue(
+        // what should be returned from this function?
+        );
+      mockDeleteAssessmentById
+        .mockResolvedValue(
+        // what should be returned from this function?
+        );
+      appAgent.delete(`/${assessmentId}`).expect(204, null, err => {
+        expect(mockGetProgramIdByProgramAssessmentId)
+          .toHaveBeenCalledWith(
+          // what did we call it with?
+          );
+        expect(mockFindRoleInProgram)
+          .toHaveBeenCalledWith(
+          // what did we call it with?
+          );
+        expect(mockDeleteAssessmentById)
+          .toHaveBeenCalledWith(
+          // what did we call it with?
+          );
+        done(err);
+      });
+    });
+    it('should return an error if logged-in user is not a facilitator of that program', done => {
+      const principalId =3;
+      const assessmentId = 1;
+      mockPrincipalId(principalId);
+      mockGetProgramIdByProgramAssessmentId
+        .mockResolvedValue(
+        // what should be returned from this function?
+        );
+      mockFindRoleInProgram
+        .mockResolvedValue(
+        // what should be returned from this function?
+        );
+      appAgent.delete(`/${assessmentId}`).expect(
+        401,
+        {
+          // what goes here?
+        },
+        err => {
+          expect(mockGetProgramIdByProgramAssessmentId)
+            .toHaveBeenCalledWith(
+            // what did we call it with?
+            );
+          expect(mockFindRoleInProgram)
+            .toHaveBeenCalledWith(
+            // what did we call it with?
+            );
           done(err);
-        });
+        }
+      );
     });
   });
 

--- a/api/src/middleware/__tests__/assessmentsRouter.ts
+++ b/api/src/middleware/__tests__/assessmentsRouter.ts
@@ -82,11 +82,17 @@ describe('assessmentsRouter', () => {
       mockFindRoleInProgram.mockResolvedValue({ title: 'participant' });
       appAgent
         .delete(`/${assessmentId}`)
-        .expect(401, errorEnvelope('Unauthorized user.'), err => {
-          expect(mockGetProgramIdByProgramAssessmentId).toHaveBeenCalledWith(1);
-          expect(mockFindRoleInProgram).toHaveBeenCalledWith(principalId, 2);
-          done(err);
-        });
+        .expect(
+          401,
+          errorEnvelope('The requester does not have access to the resource.'),
+          err => {
+            expect(mockGetProgramIdByProgramAssessmentId).toHaveBeenCalledWith(
+              1
+            );
+            expect(mockFindRoleInProgram).toHaveBeenCalledWith(principalId, 2);
+            done(err);
+          }
+        );
     });
   });
 

--- a/api/src/services/assessmentService.ts
+++ b/api/src/services/assessmentService.ts
@@ -489,8 +489,7 @@ export const submissionDetails = async (
     .where({ assessment_id: assessmentId });
 
   if (isResponsesIncluded) {
-    const assessmentSubmissionIds =
-      assessmentSubmissionByProgramAssessmentId.map(element => element.id);
+    //const assessmentSubmissionIds =   assessmentSubmissionByProgramAssessmentId.map(element => element.id);
     const responses = await db<AssessmentResponse>('assessment_responses')
       .select('*')
       .where({ submission_id: submissionId });


### PR DESCRIPTION
## Proposed changes

This pull request resolves #541 by adding test for assessment deletion route

## Checklist

- [x] Related issue appears at beginning of pull request title with pound sign, and title describes the changes being proposed.
- [x] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] The appropriate label has been chosen for this pull request.
- [x] The correct project has been selected for this pull request.
- [x] All commits in this branch, including merge commits, begin with the issue number and a pound sign.
- [x] Tests have been added, where appropriate; or, no tests are relevant for this pull request.
- [x] This pull request contains UI changes, and screenshots of those UI images appear below; or, this pull request contains no UI changes.