### PR TITLE
#563 Implement working functionality for the PUT /program/:programAssessmentId route

### DIFF
--- a/api/src/assets/data.ts
+++ b/api/src/assets/data.ts
@@ -150,12 +150,19 @@ export const exampleProgramAssessmentsRow = {
   available_after: '2023-02-06',
   due_date: '2023-02-10',
 };
+export const updateProgramAssessmentsRow: ProgramAssessment = {
+  id:15,
+  program_id: 1,
+  assessment_id: 12,
+  available_after: '2023-02-06',
+  due_date: '2023-02-10',
+};
 
 export const exampleProgramAssessment: ProgramAssessment = {
   id: 15,
   program_id: 1,
   assessment_id: 12,
-  available_after: '2023-02-06',
+  available_after: '2023-03-06',
   due_date: '2023-02-10',
 };
 

--- a/api/src/assets/data.ts
+++ b/api/src/assets/data.ts
@@ -150,19 +150,20 @@ export const exampleProgramAssessmentsRow = {
   available_after: '2023-02-06',
   due_date: '2023-02-10',
 };
-export const updateProgramAssessmentsRow: ProgramAssessment = {
-  id:15,
+
+export const updatedProgramAssessmentsRow = {
+  id: 15,
   program_id: 1,
   assessment_id: 12,
-  available_after: '2023-02-06',
-  due_date: '2023-02-10',
+  available_after: '2023-03-06',
+  due_date: '2023-04-10',
 };
 
 export const exampleProgramAssessment: ProgramAssessment = {
   id: 15,
   program_id: 1,
   assessment_id: 12,
-  available_after: '2023-03-06',
+  available_after: '2023-02-06',
   due_date: '2023-02-10',
 };
 

--- a/api/src/middleware/__tests__/assessmentsRouter.ts
+++ b/api/src/middleware/__tests__/assessmentsRouter.ts
@@ -114,13 +114,10 @@ describe('assessmentsRouter', () => {
     it('should respond with an Unauthorized Error if the logged-in principal id is not the facilitator', done => {
       mockFindProgramAssessment.mockResolvedValue(exampleProgramAssessment);
       mockGetPrincipalProgramRole.mockResolvedValue(null);
-      mockUpdateProgramAssessment.mockResolvedValue(
-        updatedProgramAssessmentsRow
-      );
+
       mockPrincipalId(otherParticipantPrincipalId);
 
       appAgent
-
         .put(`/program/${exampleProgramAssessment.id}`)
         .send(updatedProgramAssessmentsRow)
         .expect(
@@ -136,9 +133,6 @@ describe('assessmentsRouter', () => {
             expect(mockGetPrincipalProgramRole).toHaveBeenCalledWith(
               otherParticipantPrincipalId,
               exampleProgramAssessment.program_id
-            );
-            mockUpdateProgramAssessment.mockResolvedValue(
-              updatedProgramAssessmentsRow
             );
 
             done(err);
@@ -170,14 +164,10 @@ describe('assessmentsRouter', () => {
 
       mockFindProgramAssessment.mockResolvedValue(exampleProgramAssessment);
       mockGetPrincipalProgramRole.mockResolvedValue('Facilitator');
-      mockUpdateProgramAssessment.mockResolvedValue(
-        updatedProgramAssessmentsRow
-      );
 
       mockPrincipalId(otherParticipantPrincipalId);
 
       appAgent
-
         .put(`/program/${exampleProgramAssessment.id}`)
         .send(exampleAssessmentFormUser)
         .expect(
@@ -191,9 +181,6 @@ describe('assessmentsRouter', () => {
             expect(mockGetPrincipalProgramRole).toHaveBeenCalledWith(
               otherParticipantPrincipalId,
               exampleProgramAssessment.program_id
-            );
-            mockUpdateProgramAssessment.mockResolvedValue(
-              updatedProgramAssessmentsRow
             );
 
             done(err);

--- a/api/src/middleware/assessmentsRouter.ts
+++ b/api/src/middleware/assessmentsRouter.ts
@@ -7,16 +7,17 @@ import {
 } from './httpErrors';
 import { itemEnvelope, collectionEnvelope } from './responseEnvelope';
 
-import { SavedAssessment, CurriculumAssessment,ProgramAssessment } from '../models';
+import {
+  SavedAssessment,
+  CurriculumAssessment,
+  ProgramAssessment,
+} from '../models';
 import {
   findProgramAssessment,
   getAssessmentSubmission,
   getCurriculumAssessment,
   getPrincipalProgramRole,
   updateProgramAssessment,
-   
-
-  
 } from '../services/assessmentsService';
 
 const assessmentsRouter = Router();
@@ -67,64 +68,67 @@ assessmentsRouter.post('/program', async (req, res, next) => {
 assessmentsRouter.put(
   '/program/:programAssessmentId',
   async (req, res, next) => {
-    const {programAssessmentId} = req.params;
-    const {principalId} = req.session;
+    const { programAssessmentId } = req.params;
+    const { principalId } = req.session;
     const programAssessmentFromUser = req.body;
     const programAssessmentIdParsed = Number(programAssessmentId);
-    if (!Number.isInteger(programAssessmentIdParsed) || programAssessmentIdParsed < 1) {
-      next(new BadRequestError(`"${programAssessmentIdParsed}" is not a valid program id.`));
-      return;
-    }
-    let updatedPrgramAssessment;
-   try{
-    
-
-    const programAssessment = await findProgramAssessment(programAssessmentIdParsed);
-   console.log("program",programAssessment)
-    // get the principal program role
-    const programRole = await getPrincipalProgramRole(
-      principalId,
-      programAssessment.program_id
-    );
-    
-
-    // if the program role is null/falsy, that means the user is not enrolled in
-    // the program. send an error back to the user.
-    if (!programRole) {
+    if (
+      !Number.isInteger(programAssessmentIdParsed) ||
+      programAssessmentIdParsed < 1
+    ) {
       next(
-        new UnauthorizedError(
-          `Could not access programAssessment  with ID ${programAssessmentIdParsed}.`
+        new BadRequestError(
+          `"${programAssessmentIdParsed}" is not a valid program id.`
         )
       );
       return;
     }
-
-
-    const isprogramAssessment = (possibleAssessment: unknown): possibleAssessment is ProgramAssessment => {
-      return (possibleAssessment as ProgramAssessment).id !== undefined;
-    }
-
-    if (!isprogramAssessment(programAssessmentFromUser)) {
-      next(
-        new BadRequestError(`Was not given a valid  program  assessment.`)
+    let updatedPrgramAssessment;
+    try {
+      const programAssessment = await findProgramAssessment(
+        programAssessmentIdParsed
       );
-      return;
-    }
-  
-    updatedPrgramAssessment = await updateProgramAssessment(
-      
-      programAssessmentFromUser
-    );
-    console.log(" updatedPrgramAssessment", updatedPrgramAssessment)
-    
+      console.log('program', programAssessment);
+      // get the principal program role
+      const programRole = await getPrincipalProgramRole(
+        principalId,
+        programAssessment.program_id
+      );
 
-   }catch (error) {
+      // if the program role is null/falsy, that means the user is not enrolled in
+      // the program. send an error back to the user.
+      if (!programRole) {
+        next(
+          new UnauthorizedError(
+            `Could not access programAssessment  with ID ${programAssessmentIdParsed}.`
+          )
+        );
+        return;
+      }
+
+      const isprogramAssessment = (
+        possibleAssessment: unknown
+      ): possibleAssessment is ProgramAssessment => {
+        return (possibleAssessment as ProgramAssessment).id !== undefined;
+      };
+
+      if (!isprogramAssessment(programAssessmentFromUser)) {
+        next(
+          new BadRequestError(`Was not given a valid  program  assessment.`)
+        );
+        return;
+      }
+
+      updatedPrgramAssessment = await updateProgramAssessment(
+        programAssessmentFromUser
+      );
+      console.log(' updatedPrgramAssessment', updatedPrgramAssessment);
+    } catch (error) {
       next(error);
       return;
-   }
+    }
 
-   res.status(201).json(itemEnvelope(updatedPrgramAssessment));
-
+    res.status(201).json(itemEnvelope(updatedPrgramAssessment));
   }
 );
 // Delete an existing ProgramAssessment

--- a/api/src/middleware/assessmentsRouter.ts
+++ b/api/src/middleware/assessmentsRouter.ts
@@ -13,6 +13,8 @@ import {
   getAssessmentSubmission,
   getCurriculumAssessment,
   getPrincipalProgramRole,
+  updateProgramAssessment
+  
 } from '../services/assessmentsService';
 
 const assessmentsRouter = Router();
@@ -63,7 +65,25 @@ assessmentsRouter.post('/program', async (req, res, next) => {
 assessmentsRouter.put(
   '/program/:programAssessmentId',
   async (req, res, next) => {
-    res.json();
+    const {programAssessmentId} = req.params;
+    const {principalId} = req.session;
+    const { completed } = req.body;
+    const programAssessmentIdParsed = Number(programAssessmentId);
+    if (!Number.isInteger(programAssessmentIdParsed) || programAssessmentIdParsed < 1) {
+      next(new BadRequestError(`"${programAssessmentIdParsed}" is not a valid program id.`));
+      return;
+    }
+    let updatedPrgramAssessment;
+   try{
+    updatedPrgramAssessment = await updateProgramAssessment
+
+   }catch (error) {
+      next(error);
+      return;
+   }
+
+   res.status(201).json(itemEnvelope(updatedPrgramAssessment));
+
   }
 );
 // Delete an existing ProgramAssessment

--- a/api/src/middleware/assessmentsRouter.ts
+++ b/api/src/middleware/assessmentsRouter.ts
@@ -88,7 +88,7 @@ assessmentsRouter.put(
       const programAssessment = await findProgramAssessment(
         programAssessmentIdParsed
       );
-      console.log('program', programAssessment);
+
       // get the principal program role
       const programRole = await getPrincipalProgramRole(
         principalId,
@@ -100,7 +100,7 @@ assessmentsRouter.put(
       if (!programRole) {
         next(
           new UnauthorizedError(
-            `Could not access programAssessment  with ID ${programAssessmentIdParsed}.`
+            `Could not access program Assessment with ID ${programAssessmentIdParsed}.`
           )
         );
         return;
@@ -113,16 +113,13 @@ assessmentsRouter.put(
       };
 
       if (!isprogramAssessment(programAssessmentFromUser)) {
-        next(
-          new BadRequestError(`Was not given a valid  program  assessment.`)
-        );
+        next(new BadRequestError(`Was not given a valid program assessment.`));
         return;
       }
 
       updatedPrgramAssessment = await updateProgramAssessment(
         programAssessmentFromUser
       );
-      console.log(' updatedPrgramAssessment', updatedPrgramAssessment);
     } catch (error) {
       next(error);
       return;

--- a/api/src/middleware/assessmentsRouter.ts
+++ b/api/src/middleware/assessmentsRouter.ts
@@ -23,6 +23,7 @@ import {
   listProgramAssessments,
   facilitatorProgramAssessmentsForCurriculumAssessment,
   updateCurriculumAssessment,
+  updateProgramAssessment,
 } from '../services/assessmentsService';
 
 const assessmentsRouter = Router();
@@ -155,10 +156,12 @@ assessmentsRouter.get(
     res.json();
   }
 );
+
 // Create a new ProgramAssessment
 assessmentsRouter.post('/program', async (req, res, next) => {
   res.json();
 });
+
 // Update an existing ProgramAssessment
 assessmentsRouter.put(
   '/program/:programAssessmentId',
@@ -173,7 +176,7 @@ assessmentsRouter.put(
     ) {
       next(
         new BadRequestError(
-          `"${programAssessmentIdParsed}" is not a valid program id.`
+          `"${programAssessmentIdParsed}" is not a valid program assessment ID.`
         )
       );
       return;
@@ -183,6 +186,12 @@ assessmentsRouter.put(
       const programAssessment = await findProgramAssessment(
         programAssessmentIdParsed
       );
+
+      if (programAssessment === null) {
+        throw new NotFoundError(
+          `Could not find program assessment with ID ${programAssessmentIdParsed}.`
+        );
+      }
 
       // get the principal program role
       const programRole = await getPrincipalProgramRole(
@@ -223,6 +232,7 @@ assessmentsRouter.put(
     res.status(201).json(itemEnvelope(updatedPrgramAssessment));
   }
 );
+
 // Delete an existing ProgramAssessment
 assessmentsRouter.delete(
   '/program/:programAssessmentId',

--- a/api/src/services/__tests__/assessmentsService.ts
+++ b/api/src/services/__tests__/assessmentsService.ts
@@ -18,6 +18,8 @@ import {
   updateAssessmentSubmission,
   updateCurriculumAssessment,
   updateProgramAssessment,
+
+
 } from '../assessmentsService';
 
 import {
@@ -36,6 +38,7 @@ import {
   matchingAssessmentQuestionsRow,
   matchingAssessmentAnswersRow,
   unenrolledPrincipalId,
+  updateProgramAssessmentsRow
 } from '../../assets/data';
 
 describe('assessmentsService', () => {
@@ -229,5 +232,30 @@ describe('assessmentsService', () => {
 
   describe('updateCurriculumAssessment', () => {});
 
-  describe('updateProgramAssessment', () => {});
+  describe('updateProgramAssessment', () => {
+    it('should return update for an existing program assessment id ', async () => {
+      mockQuery(
+        'select `program_id`, `assessment_id`, `available_after`, `due_date` from `program_assessments` where `id` = ?',
+        [exampleProgramAssessment.id],
+        [exampleProgramAssessmentsRow]
+      );
+      mockQuery(
+        'select `program_participant_roles`.`title` from `program_participants` inner join `program_participant_roles` on `program_participant_roles`.`id` = `program_participants`.`role_id` where `principal_id` = ? and `program_id` = ?',
+        [participantPrincipalId, exampleProgramAssessment.program_id],
+        [exampleProgramParticipantRoleParticipantRow]
+      );
+      mockQuery(
+        'update `available_after`, `due_date` from `program_assessments` where `id` = ?',
+        [exampleProgramAssessment.id],
+        []
+      );
+     
+    
+ 
+      expect(await updateProgramAssessment(exampleProgramAssessment)).toEqual(
+        updateProgramAssessmentsRow
+      );
+
+  });
+});
 });

--- a/api/src/services/__tests__/assessmentsService.ts
+++ b/api/src/services/__tests__/assessmentsService.ts
@@ -18,8 +18,6 @@ import {
   updateAssessmentSubmission,
   updateCurriculumAssessment,
   updateProgramAssessment,
-
-
 } from '../assessmentsService';
 
 import {
@@ -38,7 +36,7 @@ import {
   matchingAssessmentQuestionsRow,
   matchingAssessmentAnswersRow,
   unenrolledPrincipalId,
-  updateProgramAssessmentsRow
+  updatedProgramAssessmentsRow,
 } from '../../assets/data';
 
 describe('assessmentsService', () => {
@@ -233,29 +231,20 @@ describe('assessmentsService', () => {
   describe('updateCurriculumAssessment', () => {});
 
   describe('updateProgramAssessment', () => {
-    it('should return update for an existing program assessment id ', async () => {
+    it('should return update for an existing program assessment ID', async () => {
       mockQuery(
-        'select `program_id`, `assessment_id`, `available_after`, `due_date` from `program_assessments` where `id` = ?',
-        [exampleProgramAssessment.id],
-        [exampleProgramAssessmentsRow]
-      );
-      mockQuery(
-        'select `program_participant_roles`.`title` from `program_participants` inner join `program_participant_roles` on `program_participant_roles`.`id` = `program_participants`.`role_id` where `principal_id` = ? and `program_id` = ?',
-        [participantPrincipalId, exampleProgramAssessment.program_id],
-        [exampleProgramParticipantRoleParticipantRow]
-      );
-      mockQuery(
-        'update `available_after`, `due_date` from `program_assessments` where `id` = ?',
-        [exampleProgramAssessment.id],
+        'update `program_assessments` set `available_after` = ?, `due_date` = ? where `id` = ?',
+        [
+          updatedProgramAssessmentsRow.available_after,
+          updatedProgramAssessmentsRow.due_date,
+          updatedProgramAssessmentsRow.id,
+        ],
         []
       );
-     
-    
- 
-      expect(await updateProgramAssessment(exampleProgramAssessment)).toEqual(
-        updateProgramAssessmentsRow
-      );
 
+      expect(
+        await updateProgramAssessment(updatedProgramAssessmentsRow)
+      ).toEqual(updatedProgramAssessmentsRow);
+    });
   });
-});
 });

--- a/api/src/services/assessmentsService.ts
+++ b/api/src/services/assessmentsService.ts
@@ -240,7 +240,6 @@ const listAssessmentQuestions = async (
   const listAssessmentAnswers = await db('assessment_answers')
     .select('id', 'question_id', 'title', 'description', 'sort_order')
     .whereIn('question_id', questionIds);
-  console.log(listAssessmentAnswers);
 
   matchinglistAssessmentQuestionsRows
     .filter(
@@ -829,12 +828,12 @@ export const updateCurriculumAssessment = async (
 export const updateProgramAssessment = async (
   programAssessment: ProgramAssessment
 ): Promise<ProgramAssessment> => {
-  const numberOfRowsUpdated = await db('program_assessments')
+  await db('program_assessments')
     .update({
       available_after: programAssessment.available_after,
       due_date: programAssessment.due_date,
     })
     .where('id', programAssessment.id);
- 
+
   return programAssessment;
 };

--- a/api/src/services/assessmentsService.ts
+++ b/api/src/services/assessmentsService.ts
@@ -48,7 +48,7 @@ const calculateNumParticipantsWithSubmissions = async (
   if (numParticipantsWithSubmissions === 0) {
     return null;
   }
-  return numParticipantsWithSubmissions as number;
+  return numParticipantsWithSubmissions;
 };
 
 /**
@@ -240,6 +240,7 @@ const listAssessmentQuestions = async (
   const listAssessmentAnswers = await db('assessment_answers')
     .select('id', 'question_id', 'title', 'description', 'sort_order')
     .whereIn('question_id', questionIds);
+  console.log(listAssessmentAnswers);
 
   matchinglistAssessmentQuestionsRows
     .filter(
@@ -826,7 +827,14 @@ export const updateCurriculumAssessment = async (
  *   that was handed to us, if update was successful.
  */
 export const updateProgramAssessment = async (
-  programAssessment: CurriculumAssessment
+  programAssessment: ProgramAssessment
 ): Promise<ProgramAssessment> => {
-  return;
+  const numberOfRowsUpdated = await db('program_assessments')
+    .update({
+      available_after: programAssessment.available_after,
+      due_date: programAssessment.due_date,
+    })
+    .where('id', programAssessment.id);
+ 
+  return programAssessment;
 };


### PR DESCRIPTION
## Proposed changes

This pull request resolves #563 by adding routing and service file functions for the `PUT /program/:programAssessmentId` route.

It returns an `UnauthorizedError` if logged-in user is not a facilitator.

It responds with a `NotFoundError` if the program assessment ID was not found in the`program_assessments` database table.

Otherwise, it updates an existing program assessment in the database.

## Checklist

- [x] Related issue appears at beginning of pull request title with pound sign, and title describes the changes being proposed.
- [x] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] The appropriate label has been chosen for this pull request.
- [x] The correct project has been selected for this pull request.
- [x] All commits in this branch, including merge commits, begin with the issue number and a pound sign.
- [x] Tests have been added, where appropriate; or, no tests are relevant for this pull request.
- [x] This pull request contains UI changes, and screenshots of those UI images appear below; or, this pull request contains no UI changes.
