### PR TITLE
#567 Implement working functionality for the GET /program/:programAssessmentId/submissions route

### DIFF
--- a/api/src/assets/data.ts
+++ b/api/src/assets/data.ts
@@ -6,6 +6,7 @@ import {
   AssessmentSubmission,
   AssessmentWithSummary,
   Question,
+  AssessmentWithSubmissions,
 } from '../models';
 export const administratorPrincipalId = 3;
 export const participantPrincipalId = 30;
@@ -184,12 +185,17 @@ export const exampleFacilitatorAssessmentSubmissionsSummary: FacilitatorAssessme
     num_ungraded_submissions: 6,
   };
 
-export const exampleAssessmentSubmissionInProgress: AssessmentSubmission = {
+export const exampleAssessmentSubmissionOpened: AssessmentSubmission = {
   id: 2,
   assessment_id: exampleProgramAssessment.id,
   principal_id: participantPrincipalId,
-  assessment_submission_state: 'In Progress',
+  assessment_submission_state: 'Opened',
   opened_at: '2023-02-09 12:00:00',
+};
+
+export const exampleAssessmentSubmissionInProgress: AssessmentSubmission = {
+  ...exampleAssessmentSubmissionOpened,
+  assessment_submission_state: 'In Progress',
   responses: [
     {
       id: 1,
@@ -202,7 +208,7 @@ export const exampleAssessmentSubmissionInProgress: AssessmentSubmission = {
 };
 
 export const exampleAssessmentSubmissionSubmitted: AssessmentSubmission = {
-  ...exampleAssessmentSubmissionInProgress,
+  ...exampleAssessmentSubmissionOpened,
   assessment_submission_state: 'Submitted',
   submitted_at: '2023-02-09 13:23:45',
   responses: [
@@ -214,6 +220,14 @@ export const exampleAssessmentSubmissionSubmitted: AssessmentSubmission = {
       answer_id: 1,
     },
   ],
+};
+
+export const exampleOtherAssessmentSubmissionSubmitted: AssessmentSubmission = {
+  ...exampleAssessmentSubmissionOpened,
+  assessment_submission_state: 'Submitted',
+  submitted_at: '2023-02-09 13:23:45',
+  principal_id: otherParticipantPrincipalId,
+  id: 3,
 };
 
 export const assessmentSubmissionsRowGraded = {
@@ -253,3 +267,22 @@ export const exampleAssessmentSubmissionGraded: AssessmentSubmission = {
     },
   ],
 };
+
+export const exampleParticipantAssessmentWithSubmissions: AssessmentWithSubmissions =
+  {
+    curriculum_assessment: exampleCurriculumAssessment,
+    program_assessment: exampleProgramAssessment,
+    principal_program_role: 'Participant',
+    submissions: [exampleAssessmentSubmissionInProgress],
+  };
+
+export const exampleFacilitatorAssessmentWithSubmissions: AssessmentWithSubmissions =
+  {
+    curriculum_assessment: exampleCurriculumAssessment,
+    program_assessment: exampleProgramAssessment,
+    principal_program_role: 'Facilitator',
+    submissions: [
+      exampleAssessmentSubmissionInProgress,
+      exampleOtherAssessmentSubmissionSubmitted,
+    ],
+  };

--- a/api/src/assets/data.ts
+++ b/api/src/assets/data.ts
@@ -185,12 +185,24 @@ export const exampleFacilitatorAssessmentSubmissionsSummary: FacilitatorAssessme
     num_ungraded_submissions: 6,
   };
 
+export const matchingAssessmentSubmissionOpenedRow = {
+  id: 2,
+  assessment_id: exampleProgramAssessment.id,
+  principal_id: participantPrincipalId,
+  assessment_submission_state: 'Opened',
+  opened_at: '2023-02-09 12:00:00',
+  submitted_at: null as string,
+  score: null as number,
+};
+
 export const exampleAssessmentSubmissionOpened: AssessmentSubmission = {
   id: 2,
   assessment_id: exampleProgramAssessment.id,
   principal_id: participantPrincipalId,
   assessment_submission_state: 'Opened',
   opened_at: '2023-02-09 12:00:00',
+  submitted_at: null as string,
+  score: null as number,
 };
 
 export const exampleAssessmentSubmissionInProgress: AssessmentSubmission = {
@@ -222,12 +234,23 @@ export const exampleAssessmentSubmissionSubmitted: AssessmentSubmission = {
   ],
 };
 
+export const matchingOtherAssessmentSubmissionSubmittedRow = {
+  id: 3,
+  assessment_id: exampleProgramAssessment.id,
+  principal_id: otherParticipantPrincipalId,
+  assessment_submission_state: 'Submitted',
+  opened_at: '2023-02-09 12:00:00',
+  submitted_at: '2023-02-09 13:23:45',
+  score: null as number,
+};
+
 export const exampleOtherAssessmentSubmissionSubmitted: AssessmentSubmission = {
   ...exampleAssessmentSubmissionOpened,
   assessment_submission_state: 'Submitted',
   submitted_at: '2023-02-09 13:23:45',
   principal_id: otherParticipantPrincipalId,
   id: 3,
+  score: null as number,
 };
 
 export const assessmentSubmissionsRowGraded = {

--- a/api/src/middleware/__tests__/assessmentsRouter.ts
+++ b/api/src/middleware/__tests__/assessmentsRouter.ts
@@ -21,6 +21,9 @@ import {
   exampleParticipantAssessmentSubmissionsSummary,
   exampleFacilitatorAssessmentSubmissionsSummary,
   exampleCurriculumAssessment,
+  exampleOtherAssessmentSubmissionSubmitted,
+  exampleParticipantAssessmentWithSubmissions,
+  exampleFacilitatorAssessmentWithSubmissions,
 } from '../../assets/data';
 import {
   constructFacilitatorAssessmentSummary,
@@ -35,6 +38,7 @@ import {
   getAssessmentSubmission,
   getCurriculumAssessment,
   getPrincipalProgramRole,
+  listAllProgramAssessmentSubmissions,
   listParticipantProgramAssessmentSubmissions,
   listPrincipalEnrolledProgramIds,
   listProgramAssessments,
@@ -64,6 +68,9 @@ const mockGetCurriculumAssessment = jest.mocked(getCurriculumAssessment);
 const mockGetPrincipalProgramRole = jest.mocked(getPrincipalProgramRole);
 const mockFacilitatorProgramIdsMatchingCurriculum = jest.mocked(
   facilitatorProgramIdsMatchingCurriculum
+);
+const mockListAllProgramAssessmentSubmissions = jest.mocked(
+  listAllProgramAssessmentSubmissions
 );
 const mockListParticipantProgramAssessmentSubmissions = jest.mocked(
   listParticipantProgramAssessmentSubmissions
@@ -465,7 +472,155 @@ describe('assessmentsRouter', () => {
   });
   describe('DELETE /program/:programAssessmentId', () => {});
 
-  describe('GET /program/:programAssessmentId/submissions', () => {});
+  describe('GET /program/:programAssessmentId/submissions', () => {
+    it('should show a facilitator an AssessmentWithSubmissions with all participant submissions', done => {
+      mockFindProgramAssessment.mockResolvedValue(exampleProgramAssessment);
+      mockGetPrincipalProgramRole.mockResolvedValue('Facilitator');
+      mockListAllProgramAssessmentSubmissions.mockResolvedValue([
+        exampleAssessmentSubmissionInProgress,
+        exampleOtherAssessmentSubmissionSubmitted,
+      ]);
+      mockGetCurriculumAssessment.mockResolvedValue(
+        exampleCurriculumAssessment
+      );
+
+      mockPrincipalId(facilitatorPrincipalId);
+
+      appAgent
+        .get(`/program/${exampleProgramAssessment.id}/submissions`)
+        .expect(
+          200,
+          itemEnvelope(exampleFacilitatorAssessmentWithSubmissions),
+          err => {
+            expect(mockFindProgramAssessment).toHaveBeenCalledWith(
+              exampleProgramAssessment.id
+            );
+
+            expect(mockGetPrincipalProgramRole).toHaveBeenCalledWith(
+              facilitatorPrincipalId,
+              exampleProgramAssessment.program_id
+            );
+
+            expect(
+              mockListAllProgramAssessmentSubmissions
+            ).toHaveBeenCalledWith(exampleProgramAssessment.id);
+
+            expect(mockGetCurriculumAssessment).toHaveBeenCalledWith(
+              exampleProgramAssessment.assessment_id,
+              false,
+              false
+            );
+
+            done(err);
+          }
+        );
+    });
+
+    it('should show a participant an AssessmentWithSubmissions with their submissions', done => {
+      mockFindProgramAssessment.mockResolvedValue(exampleProgramAssessment);
+      mockGetPrincipalProgramRole.mockResolvedValue('Participant');
+      mockListParticipantProgramAssessmentSubmissions.mockResolvedValue([
+        exampleAssessmentSubmissionInProgress,
+      ]);
+      mockGetCurriculumAssessment.mockResolvedValue(
+        exampleCurriculumAssessment
+      );
+
+      mockPrincipalId(participantPrincipalId);
+      appAgent
+        .get(`/program/${exampleProgramAssessment.id}/submissions`)
+        .expect(
+          200,
+          itemEnvelope(exampleParticipantAssessmentWithSubmissions),
+          err => {
+            expect(mockFindProgramAssessment).toHaveBeenCalledWith(
+              exampleProgramAssessment.id
+            );
+
+            expect(mockGetPrincipalProgramRole).toHaveBeenCalledWith(
+              participantPrincipalId,
+              exampleProgramAssessment.program_id
+            );
+
+            expect(
+              mockListParticipantProgramAssessmentSubmissions
+            ).toHaveBeenCalledWith(
+              participantPrincipalId,
+              exampleProgramAssessment.id
+            );
+
+            expect(mockGetCurriculumAssessment).toHaveBeenCalledWith(
+              exampleProgramAssessment.assessment_id,
+              false,
+              false
+            );
+
+            done(err);
+          }
+        );
+    });
+
+    it('should give an UnauthorizedError to anyone not enrolled in the course', done => {
+      mockFindProgramAssessment.mockResolvedValue(exampleProgramAssessment);
+      mockGetPrincipalProgramRole.mockResolvedValue(null);
+
+      mockPrincipalId(unenrolledPrincipalId);
+      appAgent
+        .get(`/program/${exampleProgramAssessment.id}/submissions`)
+        .expect(
+          401,
+          errorEnvelope(
+            `Could not access program assessment with ID ${exampleProgramAssessment.id} without enrollment.`
+          ),
+          err => {
+            expect(mockFindProgramAssessment).toHaveBeenCalledWith(
+              exampleProgramAssessment.id
+            );
+
+            expect(mockGetPrincipalProgramRole).toHaveBeenCalledWith(
+              unenrolledPrincipalId,
+              exampleProgramAssessment.program_id
+            );
+
+            done(err);
+          }
+        );
+    });
+
+    it('should give a NotFoundError for a programAssessmentId not found in the database', done => {
+      mockFindProgramAssessment.mockResolvedValue(null);
+
+      mockPrincipalId(participantPrincipalId);
+      appAgent
+        .get(`/program/${exampleProgramAssessment.id}/submissions`)
+        .expect(
+          404,
+          errorEnvelope(
+            `Could not find program assessment with ID ${exampleProgramAssessment.id}`
+          ),
+          err => {
+            expect(mockFindProgramAssessment).toHaveBeenCalledWith(
+              exampleProgramAssessment.id
+            );
+
+            done(err);
+          }
+        );
+    });
+
+    it('should give a BadRequestError for an invalid programAssessmentId', done => {
+      mockPrincipalId(participantPrincipalId);
+      appAgent
+        .get(`/program/test/submissions`)
+        .expect(
+          400,
+          errorEnvelope(`"test" is not a valid program assessment ID.`),
+          err => {
+            done(err);
+          }
+        );
+    });
+  });
   describe('GET /program/:programAssessmentId/submissions/new', () => {});
 
   describe('GET /submissions/:submissionId', () => {

--- a/api/src/middleware/assessmentsRouter.ts
+++ b/api/src/middleware/assessmentsRouter.ts
@@ -442,7 +442,7 @@ assessmentsRouter.get(
         submissions,
       };
 
-      res.json(assessmentWithSubmissions);
+      res.json(itemEnvelope(assessmentWithSubmissions));
     } catch (error) {
       next(error);
       return;

--- a/api/src/services/__tests__/assessmentsService.ts
+++ b/api/src/services/__tests__/assessmentsService.ts
@@ -13,6 +13,7 @@ import {
   getAssessmentSubmission,
   getCurriculumAssessment,
   getPrincipalProgramRole,
+  listAllProgramAssessmentSubmissions,
   listAssessmentQuestions,
   listParticipantProgramAssessmentSubmissions,
   listPrincipalEnrolledProgramIds,
@@ -46,6 +47,10 @@ import {
   exampleParticipantAssessmentSubmissionsSummary,
   updatedProgramAssessmentsRow,
   matchingProgramRow,
+  exampleAssessmentSubmissionOpened,
+  exampleOtherAssessmentSubmissionSubmitted,
+  matchingAssessmentSubmissionOpenedRow,
+  matchingOtherAssessmentSubmissionSubmittedRow,
 } from '../../assets/data';
 
 describe('constructFacilitatorAssessmentSummary', () => {
@@ -372,7 +377,72 @@ describe('listAssessmentQuestions', () => {
   });
 });
 
-describe('listParticipantProgramAssessmentSubmissions', () => {});
+describe('listAllProgramAssessmentSubmissions', () => {
+  it('should return all program assessment submissions for a given program assessment', async () => {
+    mockQuery(
+      'select `id`, `assessment_submission_states`.`title` as `assessment_submission_state`, `principal_id`, `score`, `opened_at`, `submitted_at` from `assessment_submissions` inner join `assessment_submission_states` on `assessment_submissions`.`assessment_submission_state_id` = `assessment_submission_states`.`id` where `assessment_id` = ?',
+      [exampleAssessmentSubmissionOpened.assessment_id],
+      [
+        matchingAssessmentSubmissionOpenedRow,
+        matchingOtherAssessmentSubmissionSubmittedRow,
+      ]
+    );
+
+    expect(
+      await listAllProgramAssessmentSubmissions(
+        exampleAssessmentSubmissionOpened.assessment_id
+      )
+    ).toEqual([
+      exampleAssessmentSubmissionOpened,
+      exampleOtherAssessmentSubmissionSubmitted,
+    ]);
+  });
+
+  it('should return null if no program assessment submissions for a given program assessment', async () => {
+    mockQuery(
+      'select `id`, `assessment_submission_states`.`title` as `assessment_submission_state`, `principal_id`, `score`, `opened_at`, `submitted_at` from `assessment_submissions` inner join `assessment_submission_states` on `assessment_submissions`.`assessment_submission_state_id` = `assessment_submission_states`.`id` where `assessment_id` = ?',
+      [exampleAssessmentSubmissionOpened.assessment_id],
+      []
+    );
+
+    expect(
+      await listAllProgramAssessmentSubmissions(
+        exampleAssessmentSubmissionOpened.assessment_id
+      )
+    ).toEqual(null);
+  });
+});
+
+describe('listParticipantProgramAssessmentSubmissions', () => {
+  it('should return program assessment submissions for a participant for a given program assessment', async () => {
+    mockQuery(
+      'select `id`, `assessment_submission_states`.`title` as `assessment_submission_state`, `score`, `opened_at`, `submitted_at` from `assessment_submissions` inner join `assessment_submission_states` on `assessment_submissions`.`assessment_submission_state_id` = `assessment_submission_states`.`id` where `assessment_id` = ? and `principal_id` = ?',
+      [exampleAssessmentSubmissionOpened.assessment_id, participantPrincipalId],
+      [matchingAssessmentSubmissionOpenedRow]
+    );
+    expect(
+      await listParticipantProgramAssessmentSubmissions(
+        participantPrincipalId,
+        exampleAssessmentSubmissionOpened.assessment_id
+      )
+    ).toEqual([exampleAssessmentSubmissionOpened]);
+  });
+
+  it('should return null if no program assessment submissions for a given program assessment', async () => {
+    mockQuery(
+      'select `id`, `assessment_submission_states`.`title` as `assessment_submission_state`, `score`, `opened_at`, `submitted_at` from `assessment_submissions` inner join `assessment_submission_states` on `assessment_submissions`.`assessment_submission_state_id` = `assessment_submission_states`.`id` where `assessment_id` = ? and `principal_id` = ?',
+      [exampleAssessmentSubmissionOpened.assessment_id, participantPrincipalId],
+      []
+    );
+
+    expect(
+      await listParticipantProgramAssessmentSubmissions(
+        participantPrincipalId,
+        exampleAssessmentSubmissionOpened.assessment_id
+      )
+    ).toEqual(null);
+  });
+});
 
 describe('listPrincipalEnrolledProgramIds', () => {});
 

--- a/api/src/services/assessmentsService.ts
+++ b/api/src/services/assessmentsService.ts
@@ -796,6 +796,57 @@ export const listParticipantProgramAssessmentSubmissions = async (
 };
 
 /**
+ * Lists all submissions by all program participants for a given program
+ * assessment, if any. Does not include responses for those submissions.
+ *
+ * @param {number} programAssessmentId - The row ID of the program_assessments
+ *   table for a given program assessment.
+ * @returns {Promise<AssessmentSubmission[]>} An array of AssessmentSubmission
+ *   objects constructed from matching program assessment submissions, if any,
+ *   not including their responses.
+ */
+export const listAllProgramAssessmentSubmissions = async (
+  programAssessmentId: number
+): Promise<AssessmentSubmission[]> => {
+  const matchingAssessmentSubmissionsRows = await db('assessment_submissions')
+    .join(
+      'assessment_submission_states',
+      'assessment_submissions.assessment_submission_state_id',
+      'assessment_submission_states.id'
+    )
+    .select(
+      'id',
+      'assessment_submission_states.title as assessment_submission_state',
+      'principal_id',
+      'score',
+      'opened_at',
+      'submitted_at'
+    )
+    .where('assessment_id', programAssessmentId);
+
+  if (matchingAssessmentSubmissionsRows.length === 0) {
+    return null;
+  }
+
+  const assessmentSubmissions: AssessmentSubmission[] = [];
+
+  for (const assessmentSubmissionsRow of matchingAssessmentSubmissionsRows) {
+    assessmentSubmissions.push({
+      id: assessmentSubmissionsRow.id,
+      assessment_id: programAssessmentId,
+      principal_id: assessmentSubmissionsRow.principal_id,
+      assessment_submission_state:
+        assessmentSubmissionsRow.assessment_submission_state,
+      score: assessmentSubmissionsRow.score,
+      opened_at: assessmentSubmissionsRow.opened_at,
+      submitted_at: assessmentSubmissionsRow.submitted_at,
+    });
+  }
+
+  return assessmentSubmissions;
+};
+
+/**
  * Lists all row IDs of programs for which a principal is either enrolled as a
  * participant or is designated as facilitator.
  *

--- a/api/src/services/assessmentsService.ts
+++ b/api/src/services/assessmentsService.ts
@@ -742,6 +742,57 @@ export const getPrincipalProgramRole = async (
 };
 
 /**
+ * Lists all submissions by all program participants for a given program
+ * assessment, if any. Does not include responses for those submissions.
+ *
+ * @param {number} programAssessmentId - The row ID of the program_assessments
+ *   table for a given program assessment.
+ * @returns {Promise<AssessmentSubmission[]>} An array of AssessmentSubmission
+ *   objects constructed from matching program assessment submissions, if any,
+ *   not including their responses.
+ */
+export const listAllProgramAssessmentSubmissions = async (
+  programAssessmentId: number
+): Promise<AssessmentSubmission[]> => {
+  const matchingAssessmentSubmissionsRows = await db('assessment_submissions')
+    .join(
+      'assessment_submission_states',
+      'assessment_submissions.assessment_submission_state_id',
+      'assessment_submission_states.id'
+    )
+    .select(
+      'id',
+      'assessment_submission_states.title as assessment_submission_state',
+      'principal_id',
+      'score',
+      'opened_at',
+      'submitted_at'
+    )
+    .where('assessment_id', programAssessmentId);
+
+  if (matchingAssessmentSubmissionsRows.length === 0) {
+    return null;
+  }
+
+  const assessmentSubmissions: AssessmentSubmission[] = [];
+
+  for (const assessmentSubmissionsRow of matchingAssessmentSubmissionsRows) {
+    assessmentSubmissions.push({
+      id: assessmentSubmissionsRow.id,
+      assessment_id: programAssessmentId,
+      principal_id: assessmentSubmissionsRow.principal_id,
+      assessment_submission_state:
+        assessmentSubmissionsRow.assessment_submission_state,
+      score: assessmentSubmissionsRow.score,
+      opened_at: assessmentSubmissionsRow.opened_at,
+      submitted_at: assessmentSubmissionsRow.submitted_at,
+    });
+  }
+
+  return assessmentSubmissions;
+};
+
+/**
  * Lists all submissions by a program participant for a given program
  * assessment, if any. Does not include responses for those submissions.
  *
@@ -784,57 +835,6 @@ export const listParticipantProgramAssessmentSubmissions = async (
       id: assessmentSubmissionsRow.id,
       assessment_id: programAssessmentId,
       principal_id: participantPrincipalId,
-      assessment_submission_state:
-        assessmentSubmissionsRow.assessment_submission_state,
-      score: assessmentSubmissionsRow.score,
-      opened_at: assessmentSubmissionsRow.opened_at,
-      submitted_at: assessmentSubmissionsRow.submitted_at,
-    });
-  }
-
-  return assessmentSubmissions;
-};
-
-/**
- * Lists all submissions by all program participants for a given program
- * assessment, if any. Does not include responses for those submissions.
- *
- * @param {number} programAssessmentId - The row ID of the program_assessments
- *   table for a given program assessment.
- * @returns {Promise<AssessmentSubmission[]>} An array of AssessmentSubmission
- *   objects constructed from matching program assessment submissions, if any,
- *   not including their responses.
- */
-export const listAllProgramAssessmentSubmissions = async (
-  programAssessmentId: number
-): Promise<AssessmentSubmission[]> => {
-  const matchingAssessmentSubmissionsRows = await db('assessment_submissions')
-    .join(
-      'assessment_submission_states',
-      'assessment_submissions.assessment_submission_state_id',
-      'assessment_submission_states.id'
-    )
-    .select(
-      'id',
-      'assessment_submission_states.title as assessment_submission_state',
-      'principal_id',
-      'score',
-      'opened_at',
-      'submitted_at'
-    )
-    .where('assessment_id', programAssessmentId);
-
-  if (matchingAssessmentSubmissionsRows.length === 0) {
-    return null;
-  }
-
-  const assessmentSubmissions: AssessmentSubmission[] = [];
-
-  for (const assessmentSubmissionsRow of matchingAssessmentSubmissionsRows) {
-    assessmentSubmissions.push({
-      id: assessmentSubmissionsRow.id,
-      assessment_id: programAssessmentId,
-      principal_id: assessmentSubmissionsRow.principal_id,
       assessment_submission_state:
         assessmentSubmissionsRow.assessment_submission_state,
       score: assessmentSubmissionsRow.score,


### PR DESCRIPTION
## Proposed changes

This pull requests resolves #567 by fully implementing and testing the `GET /program/:programAssessmentId/submissions` route. The `GET /program/:programAssessmentId/submissions` gets a list of all submissions for a given program assessment (for a participant, their submissions; for a facilitator, all participant submissions).

There is full test coverage for the `GET /program/:programAssessmentId/submissions` route and the service file functions it needs. It adheres to the protocol we previously defined.

This issue continues the work from issue #515.

## Checklist

- [x] Related issue appears at beginning of pull request title with pound sign, and title describes the changes being proposed.
- [x] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] The appropriate label has been chosen for this pull request.
- [x] The correct project has been selected for this pull request.
- [x] All commits in this branch, including merge commits, begin with the issue number and a pound sign.
- [x] Tests have been added, where appropriate; or, no tests are relevant for this pull request.
- [x] This pull request contains UI changes, and screenshots of those UI images appear below; or, this pull request contains no UI changes.
