### PR TITLE
#575 Wire up the assessment submissions list frontend component to the backend API route

### DIFF
--- a/webapp/src/components/AssessmentSubmissionsListPage.tsx
+++ b/webapp/src/components/AssessmentSubmissionsListPage.tsx
@@ -74,7 +74,7 @@ const AssessmentSubmissionsListPage = () => {
       assessmentSub.curriculum_assessment.max_num_submissions >
         assessmentSub.submissions.length
     ) {
-      return <Button variant="contained">New Submission</Button>;
+      return <Button variant="contained" href={`/assessments/${assessmentIdNumber}/new`}>New Submission</Button>;
     }
     return null;
   };


### PR DESCRIPTION
## Proposed changes

This pull request resolves #575  by fully implementing and testing the [GET] assessments/assessmentId/submissions route. The [GET] assessments/assessmentId/submissions retrieve the list of submissions in the assessment_submissions table. 

If the current principal is a facilitator, retrieve all of the submissions from all participants.
If the current principal is a participant, only retrieve all of the submissions from the current principal_id.



This issue continues the work from issue #515 

## Checklist

- [x] Related issue appears at beginning of pull request title with pound sign, and title describes the changes being proposed.
- [x] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] The appropriate label has been chosen for this pull request.
- [x] The correct project has been selected for this pull request.
- [x] All commits in this branch, including merge commits, begin with the issue number and a pound sign.
- [x] Tests have been added, where appropriate; or, no tests are relevant for this pull request.
- [x] This pull request contains UI changes, and screenshots of those UI images appear below; or, this pull request contains no UI changes.
