### PR TITLE
#576 Implement working functionality for the PUT /curriculum/:curriculumAssessmentId route

### DIFF
--- a/api/src/services/assessmentsService.ts
+++ b/api/src/services/assessmentsService.ts
@@ -1268,17 +1268,43 @@ export const updateAssessmentSubmission = async (
 export const updateCurriculumAssessment = async (
   curriculumAssessment: CurriculumAssessment
 ): Promise<CurriculumAssessment> => {
-  // need to loop through and call updateAssessmentQuestion for each question that exists;
-  //
-  // need to createAssessmentQuestion for each question that does not exist;
-
+  const updatedQuestions = [];
+  const updatedCurriculumAssessment = {
+    ...curriculumAssessment
+  };
+  if (curriculumAssessment !== null) {
+    for (const question of curriculumAssessment.questions) {
+      if (typeof question.id !== "undefined") {
+        // need to createAssessmentQuestion for each question that does not exist;
+        // the question is new
+        const newQuestion = await createAssessmentQuestion(curriculumAssessment.id, question);
+        updatedQuestions.push(newQuestion);
+      } else {
+        // need to loop through and call updateAssessmentQuestion for each question that exists
+        //the question was updated
+        const updatedQuestion = await updateAssessmentQuestion(question);
+        updatedQuestions.push(updatedQuestion);
+      }
+    }
+  }
+  updatedCurriculumAssessment.questions = updatedQuestions;
   // need to update the curriculum_assessments table with any updated data for the curriculum assessment (refer to DB/model).
   // assessment_type_id turns into assessment_type. ignore assessment_type.
-
+  await db('curriculum_assessments')
+    .update({
+      title: curriculumAssessment.title,
+      assessment_type: curriculumAssessment.assessment_type,
+      description: curriculumAssessment.description,
+      max_score: curriculumAssessment.max_score,
+      max_num_submissions: curriculumAssessment.max_num_submissions,
+      time_limit: curriculumAssessment.time_limit,
+      questions: curriculumAssessment.questions
+    })
+    .where('id', curriculumAssessment.id);
   // refer to implementation of getCurriculumAssessment for knowledge on joins
   // (data in two different database tables that relate to one another), differences between database table and data type
 
-  return null;
+  return updatedCurriculumAssessment;
 };
 
 /**

--- a/api/src/services/assessmentsService.ts
+++ b/api/src/services/assessmentsService.ts
@@ -1045,6 +1045,7 @@ export const updateCurriculumAssessment = async (
   curriculumAssessment: CurriculumAssessment,
 ): Promise<CurriculumAssessment> => {
   // need to loop through and call updateAssessmentQuestion for each question that exists;
+  // 
   // need to createAssessmentQuestion for each question that does not exist;
 
   // need to update the curriculum_assessments table with any updated data for the curriculum assessment (refer to DB/model).

--- a/api/src/services/assessmentsService.ts
+++ b/api/src/services/assessmentsService.ts
@@ -105,22 +105,29 @@ const createAssessmentQuestion = async (
   question: Question
 ): Promise<Question> => {
   let questionId: number;
-  await db('questions')
-      .insert({
-        curriculum_assessment_id: curriculumAssessmentId,
-        question: question,
-        question_id: questionId,
-        assessment_id: question.assessment_id,
-        title: question.title,
-        description: question.description,
-        question_type: question.question_type,
-        answers: question.answers,
-        correct_answer_id: question.correct_answer_id,
-        max_score: question.max_score,
-        sort_order: question.sort_order,
-      })
-  return;
+  const [insertedAssessmentQuestionRowId] = await db(
+    'questions'
+  ).insert({
+    curriculum_assessment_id: curriculumAssessmentId,
+    question: question,
+    question_id: questionId,
+    assessment_id: question.assessment_id,
+    title: question.title,
+    description: question.description,
+    question_type: question.question_type,
+    answers: question.answers,
+    correct_answer_id: question.correct_answer_id,
+    max_score: question.max_score,
+    sort_order: question.sort_order,
+    })
+
+  const updatedAssessmentQuestion: Question = {
+    ...question,
+    id: insertedAssessmentQuestionRowId,
+  };
+  return updatedAssessmentQuestion;
 };
+
 
 /**
  * Inserts an answer for an existing curriculum assessment question into the
@@ -514,25 +521,7 @@ export const createCurriculumAssessment = async (
  * @returns {Promise<ProgramAssessment>} The updated ProgramAssessment object
  *   that was handed to us, but with row ID specified.
  */
-export const createProgramAssessment = async (
-  programAssessment: ProgramAssessment
-): Promise<ProgramAssessment> => {
-  const [insertedProgramAssessmentRowId] = await db(
-    'program_assessments'
-  ).insert({
-    program_id: programAssessment.program_id,
-    assessment_id: programAssessment.assessment_id,
-    available_after: programAssessment.available_after,
-    due_date: programAssessment.due_date,
-  });
 
-  const updatedProgramAssessment: ProgramAssessment = {
-    ...programAssessment,
-    id: insertedProgramAssessmentRowId,
-  };
-
-  return updatedProgramAssessment;
-};
 
 /**
  * Deletes a given curriculum assessment, all associated program assessments,

--- a/api/src/services/assessmentsService.ts
+++ b/api/src/services/assessmentsService.ts
@@ -1303,7 +1303,6 @@ export const updateCurriculumAssessment = async (
     .where('id', curriculumAssessment.id);
   // refer to implementation of getCurriculumAssessment for knowledge on joins
   // (data in two different database tables that relate to one another), differences between database table and data type
-
   return updatedCurriculumAssessment;
 };
 

--- a/api/src/services/assessmentsService.ts
+++ b/api/src/services/assessmentsService.ts
@@ -104,28 +104,28 @@ const createAssessmentQuestion = async (
   curriculumAssessmentId: number,
   question: Question
 ): Promise<Question> => {
-  let questionId: number;
-  const [insertedAssessmentQuestionRowId] = await db(
-    'questions'
-  ).insert({
-    curriculum_assessment_id: curriculumAssessmentId,
-    question: question,
-    question_id: questionId,
-    assessment_id: question.assessment_id,
-    title: question.title,
-    description: question.description,
-    question_type: question.question_type,
-    answers: question.answers,
-    correct_answer_id: question.correct_answer_id,
-    max_score: question.max_score,
-    sort_order: question.sort_order,
-    })
+  // let questionId: number;
+  // const [insertedAssessmentQuestionRowId] = await db(
+  //   'questions'
+  // ).insert({
+  //   curriculum_assessment_id: curriculumAssessmentId,
+  //   question: question,
+  //   question_id: questionId,
+  //   assessment_id: question.assessment_id,
+  //   title: question.title,
+  //   description: question.description,
+  //   question_type: question.question_type,
+  //   answers: question.answers,
+  //   correct_answer_id: question.correct_answer_id,
+  //   max_score: question.max_score,
+  //   sort_order: question.sort_order,
+  //   })
 
-  const updatedAssessmentQuestion: Question = {
-    ...question,
-    id: insertedAssessmentQuestionRowId,
-  };
-  return updatedAssessmentQuestion;
+  // const updatedAssessmentQuestion: Question = {
+  //   ...question,
+  //   id: insertedAssessmentQuestionRowId,
+  // };
+  // return updatedAssessmentQuestion;
 };
 
 
@@ -348,7 +348,7 @@ const updateAssessmentQuestion = async (
         answers: question.answers,
         correct_answer_id: question.correct_answer_id,
         max_score: question.max_score,
-        sort_order: question.sort_order,
+        sort_order: question.sort_order
       })
       .where('id', question.id);
   return;
@@ -1045,7 +1045,7 @@ export const updateCurriculumAssessment = async (
   curriculumAssessment: CurriculumAssessment,
 ): Promise<CurriculumAssessment> => {
   // need to loop through and call updateAssessmentQuestion for each question that exists;
-  // 
+  //
   // need to createAssessmentQuestion for each question that does not exist;
 
   // need to update the curriculum_assessments table with any updated data for the curriculum assessment (refer to DB/model).


### PR DESCRIPTION
## Proposed changes

This pull request includes some resolutions for issues #515 by partially implementing the `PUT assessments/:curriculum_assessments` route. The` PUT /assessments/curriculum_assessments` updates an existing `CurriculumAssessment` in the `curriculum_assessments` table, linked with a given curriculum activity.

This issue continues the work from issue #515.

## Checklist

- [x] Related issue appears at beginning of pull request title with pound sign, and title describes the changes being proposed.
- [x] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] The appropriate label has been chosen for this pull request.
- [x] The correct project has been selected for this pull request.
- [x] All commits in this branch, including merge commits, begin with the issue number and a pound sign.
- [ ] Tests have been added, where appropriate; or, no tests are relevant for this pull request.
- [x] This pull request contains UI changes, and screenshots of those UI images appear below; or, this pull request contains no UI changes.
