### PR TITLE
#579 Assessments detail page needs to be wired up to the backend

### DIFF
--- a/webapp/src/components/App.tsx
+++ b/webapp/src/components/App.tsx
@@ -71,7 +71,15 @@ const App = () => {
             }
           />
           <Route
-            path="/assessments/:assessmentId/:submissionId"
+            path="/assessments/:assessmentId/submission/:submissionId"
+            element={
+              <RequireAuth>
+                <AssessmentsDetailPage />
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="/assessments/:assessmentId/submission/new"
             element={
               <RequireAuth>
                 <AssessmentsDetailPage />

--- a/webapp/src/components/AssessmentDetailPage.tsx
+++ b/webapp/src/components/AssessmentDetailPage.tsx
@@ -271,55 +271,54 @@ const AssessmentDetailPage = () => {
 
   return (
     <Container>
-      {!isLoading && (
-        <Grid container spacing={2}>
-          <Grid item xs={12} md={6}>
-            <h1>{assessment.curriculum_assessment.title}</h1>
-          </Grid>
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={6}>
+          <h1>{assessment.curriculum_assessment.title}</h1>
+        </Grid>
 
-          <Grid item xs={12} md={12}>
-            <Grid container spacing={2}>
-              <Grid item xs={12} md={3}>
-                <AssessmentMetadataBar
-                  assessment={assessment}
-                  secondsRemaining={secondsRemaining}
-                  endTime={new Date()}
-                  submissionDisabled={submissionDisabled}
-                />
-              </Grid>
+        <Grid item xs={12} md={12}>
+          <Grid container spacing={2}>
+            <Grid item xs={12} md={3}>
+              <AssessmentMetadataBar
+                assessment={assessment}
+                secondsRemaining={secondsRemaining}
+                endTime={endTime}
+                submissionDisabled={submissionDisabled}
+              />
+            </Grid>
 
-              <Grid
-                id="assessment_display"
-                item
-                xs={12}
-                md={7.5}
-                sx={{
-                  height: '75vh',
-                  overflowX: 'auto',
-                  overflowY: 'scroll',
-                  backgroundColor: '#fafafa',
-                  boxShadow: '0 0 0.25em rgba(0,0,0,0.35)',
-                }}
-              >
-                <AssessmentDisplay
-                  assessment={assessment}
-                  handleUpdatedResponse={handleUpdatedResponse}
-                  questionsDisabled={submissionDisabled}
-                />
-              </Grid>
+            <Grid
+              id="assessment_display"
+              item
+              xs={12}
+              md={7.5}
+              sx={{
+                height: '75vh',
+                overflowX: 'auto',
+                overflowY: 'scroll',
+                backgroundColor: '#fafafa',
+                boxShadow: '0 0 0.25em rgba(0,0,0,0.35)',
+              }}
+            >
+              <AssessmentDisplay
+                assessment={assessment}
+                handleUpdatedResponse={handleUpdatedResponse}
+                questionsDisabled={submissionDisabled}
+              />
+            </Grid>
 
-              <Grid item xs={12} md={1.5}>
-                <AssessmentSubmitBar
-                  assessment={assessment}
-                  numOfAnsweredQuestions={numOfAnsweredQuestions}
-                  setShowSubmitDialog={setShowSubmitDialog}
-                  submitButtonDisabled={submissionDisabled}
-                />
-              </Grid>
+            <Grid item xs={12} md={1.5}>
+              <AssessmentSubmitBar
+                assessment={assessment}
+                numOfAnsweredQuestions={numOfAnsweredQuestions}
+                setShowSubmitDialog={setShowSubmitDialog}
+                submitButtonDisabled={submissionDisabled}
+              />
             </Grid>
           </Grid>
         </Grid>
-      )}
+      </Grid>
+      )
       <Dialog
         open={showSubmitDialog}
         onClose={() => setShowSubmitDialog(false)}

--- a/webapp/src/components/AssessmentDetailPage.tsx
+++ b/webapp/src/components/AssessmentDetailPage.tsx
@@ -318,7 +318,6 @@ const AssessmentDetailPage = () => {
           </Grid>
         </Grid>
       </Grid>
-      )
       <Dialog
         open={showSubmitDialog}
         onClose={() => setShowSubmitDialog(false)}

--- a/webapp/src/components/AssessmentDetailPage.tsx
+++ b/webapp/src/components/AssessmentDetailPage.tsx
@@ -20,11 +20,24 @@ import { AssessmentResponse, SavedAssessment } from '../types/api';
 import AssessmentMetadataBar from './AssessmentMetadataBar';
 import AssessmentDisplay from './AssessmentDisplay';
 import AssessmentSubmitBar from './AssessmentSubmitBar';
+import useApiData from '../helpers/useApiData';
 
 const AssessmentDetailPage = () => {
   const { assessmentId, submissionId } = useParams();
   const assessmentIdNumber = Number(assessmentId);
   const submissionIdNumber = Number(submissionId);
+  const path = Number.isInteger(submissionIdNumber)
+    ? `/assessments/submissions/${submissionIdNumber}`
+    : `/assessments/program/${assessmentIdNumber}/submissions/new`;
+  const {
+    data: fetchAssessment,
+    error,
+    isLoading,
+  } = useApiData<SavedAssessment>({
+    deps: [submissionIdNumber],
+    path: path,
+    sendCredentials: true,
+  });
 
   // Previously used to find the assessment details, but that will be covered by
   // the call to the backend:
@@ -33,7 +46,9 @@ const AssessmentDetailPage = () => {
   //   assessment => assessment.id === assessmentIdNumber
   // );
 
-  const [assessment, setAssessment] = useState<SavedAssessment>();
+  const [assessment, setAssessment] = useState<SavedAssessment>(
+    fetchAssessment!
+  );
   const [numOfAnsweredQuestions, setNumOfAnsweredQuestions] = useState(0);
   const [showSubmitDialog, setShowSubmitDialog] = useState(false);
   const [endTime, setEndTime] = useState<Date | null>(null);
@@ -43,7 +58,10 @@ const AssessmentDetailPage = () => {
   // First, let's load the example data. This will be replaced by the backend
   // API call in a future ticket.
   useEffect(() => {
-    setAssessment(assessmentDetailPageExampleData);
+    // setAssessment(assessmentDetailPageExampleData);
+    // if(fetchAssessment){
+    //   setAssessment(fetchAssessment);
+    //   }
   }, []);
 
   useEffect(() => {
@@ -219,9 +237,9 @@ const AssessmentDetailPage = () => {
 
   if (
     !Number.isInteger(assessmentIdNumber) ||
-    !Number.isInteger(submissionIdNumber) ||
-    assessmentIdNumber < 1 ||
-    submissionIdNumber < 1
+    //!Number.isInteger(submissionIdNumber) ||
+    assessmentIdNumber < 1 //||
+    //submissionIdNumber < 1
   ) {
     return (
       <Alert severity="error">
@@ -253,53 +271,55 @@ const AssessmentDetailPage = () => {
 
   return (
     <Container>
-      <Grid container spacing={2}>
-        <Grid item xs={12} md={6}>
-          <h1>{assessment.curriculum_assessment.title}</h1>
-        </Grid>
+      {!isLoading && (
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={6}>
+            <h1>{assessment.curriculum_assessment.title}</h1>
+          </Grid>
 
-        <Grid item xs={12} md={12}>
-          <Grid container spacing={2}>
-            <Grid item xs={12} md={3}>
-              <AssessmentMetadataBar
-                assessment={assessment}
-                secondsRemaining={secondsRemaining}
-                endTime={endTime}
-                submissionDisabled={submissionDisabled}
-              />
-            </Grid>
+          <Grid item xs={12} md={12}>
+            <Grid container spacing={2}>
+              <Grid item xs={12} md={3}>
+                <AssessmentMetadataBar
+                  assessment={assessment}
+                  secondsRemaining={secondsRemaining}
+                  endTime={new Date()}
+                  submissionDisabled={submissionDisabled}
+                />
+              </Grid>
 
-            <Grid
-              id="assessment_display"
-              item
-              xs={12}
-              md={7.5}
-              sx={{
-                height: '75vh',
-                overflowX: 'auto',
-                overflowY: 'scroll',
-                backgroundColor: '#fafafa',
-                boxShadow: '0 0 0.25em rgba(0,0,0,0.35)',
-              }}
-            >
-              <AssessmentDisplay
-                assessment={assessment}
-                handleUpdatedResponse={handleUpdatedResponse}
-                questionsDisabled={submissionDisabled}
-              />
-            </Grid>
+              <Grid
+                id="assessment_display"
+                item
+                xs={12}
+                md={7.5}
+                sx={{
+                  height: '75vh',
+                  overflowX: 'auto',
+                  overflowY: 'scroll',
+                  backgroundColor: '#fafafa',
+                  boxShadow: '0 0 0.25em rgba(0,0,0,0.35)',
+                }}
+              >
+                <AssessmentDisplay
+                  assessment={assessment}
+                  handleUpdatedResponse={handleUpdatedResponse}
+                  questionsDisabled={submissionDisabled}
+                />
+              </Grid>
 
-            <Grid item xs={12} md={1.5}>
-              <AssessmentSubmitBar
-                assessment={assessment}
-                numOfAnsweredQuestions={numOfAnsweredQuestions}
-                setShowSubmitDialog={setShowSubmitDialog}
-                submitButtonDisabled={submissionDisabled}
-              />
+              <Grid item xs={12} md={1.5}>
+                <AssessmentSubmitBar
+                  assessment={assessment}
+                  numOfAnsweredQuestions={numOfAnsweredQuestions}
+                  setShowSubmitDialog={setShowSubmitDialog}
+                  submitButtonDisabled={submissionDisabled}
+                />
+              </Grid>
             </Grid>
           </Grid>
         </Grid>
-      </Grid>
+      )}
       <Dialog
         open={showSubmitDialog}
         onClose={() => setShowSubmitDialog(false)}

--- a/webapp/src/components/AssessmentSubmissionsListPage.tsx
+++ b/webapp/src/components/AssessmentSubmissionsListPage.tsx
@@ -82,7 +82,14 @@ const AssessmentSubmissionsListPage = () => {
       assessment.curriculum_assessment.max_num_submissions >
         assessment.submissions.length
     ) {
-      return <Button variant="contained">New Submission</Button>;
+      return (
+        <Button
+          href={`/assessments/${assessmentIdNumber}/submission/new`}
+          variant="contained"
+        >
+          New Submission
+        </Button>
+      );
     }
     return null;
   };
@@ -185,7 +192,7 @@ const AssessmentSubmissionsListPage = () => {
                         <Button
                           variant="contained"
                           size="small"
-                          href={`/assessments/${assessmentIdNumber}/${submission.id}`}
+                          href={`/assessments/${assessmentIdNumber}/submission/${submission.id}`}
                         >
                           Review
                         </Button>


### PR DESCRIPTION
## Proposed changes

This close #579 integrating `AssessmentDetailPage` to three backend api:

1. GET /program/:programAssessmentId/submissions/new
2. GET /submission/:submissionId
3. PUT /submission/:submissionId

It is blocked due to the `assessment` is set before it is loaded. causing it to return error alert.

## Checklist

- [x] Related issue appears at beginning of pull request title with pound sign, and title describes the changes being proposed.
- [x] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] The appropriate label has been chosen for this pull request.
- [x] The correct project has been selected for this pull request.
- [x] All commits in this branch, including merge commits, begin with the issue number and a pound sign.
- [x] Tests have been added, where appropriate; or, no tests are relevant for this pull request.
- [ ] This pull request contains UI changes, and screenshots of those UI images appear below; or, this pull request contains no UI changes.
