### PR TITLE
#572 get program assessment route

### DIFF
--- a/api/src/assets/data.ts
+++ b/api/src/assets/data.ts
@@ -6,6 +6,7 @@ import {
   AssessmentSubmission,
   AssessmentWithSummary,
   Question,
+  AssessmentDetails
 } from '../models';
 export const administratorPrincipalId = 3;
 export const participantPrincipalId = 30;
@@ -158,6 +159,11 @@ export const exampleProgramAssessment: ProgramAssessment = {
   available_after: '2023-02-06',
   due_date: '2023-02-10',
 };
+
+export const exampleAssessmentDetails: AssessmentDetails = {
+  curriculum_assessment: exampleCurriculumAssessmentWithCorrectAnswers,
+  program_assessment: exampleProgramAssessment
+}
 
 export const exampleParticipantAssessmentSubmissionsSummary: ParticipantAssessmentSubmissionsSummary =
   {

--- a/api/src/assets/data.ts
+++ b/api/src/assets/data.ts
@@ -215,8 +215,8 @@ export const exampleProgramAssessmentNotAvailable: ProgramAssessment = {
 
 export const exampleAssessmentDetails: AssessmentDetails = {
   curriculum_assessment: exampleCurriculumAssessmentWithCorrectAnswers,
-  program_assessment: exampleProgramAssessment
-}
+  program_assessment: exampleProgramAssessment,
+};
 export const exampleParticipantAssessmentSubmissionsInactive: ParticipantAssessmentSubmissionsSummary =
   {
     principal_id: participantPrincipalId,

--- a/api/src/middleware/__tests__/assessmentsRouter.ts
+++ b/api/src/middleware/__tests__/assessmentsRouter.ts
@@ -221,7 +221,9 @@ describe('assessmentsRouter', () => {
   describe('PUT /curriculum/:curriculumAssessmentId', () => {});
   describe('DELETE /curriculum/:curriculumAssessmentId', () => {});
 
-  describe('GET /program/:programAssessmentId', () => {});
+  describe('GET /program/:programAssessmentId', () => {
+    it('should respond with a BadRequestError if given an invalid program assessment ID', done => {});
+  });
   describe('POST /program', () => {});
   describe('PUT /program/:programAssessmentId', () => {
     it('should update a program assessment if the logged-in principal ID is the program facilitator', done => {

--- a/api/src/middleware/__tests__/assessmentsRouter.ts
+++ b/api/src/middleware/__tests__/assessmentsRouter.ts
@@ -21,6 +21,7 @@ import {
   exampleParticipantAssessmentSubmissionsSummary,
   exampleFacilitatorAssessmentSubmissionsSummary,
   exampleCurriculumAssessment,
+  exampleAssessmentDetails,
 } from '../../assets/data';
 import {
   constructFacilitatorAssessmentSummary,
@@ -222,7 +223,61 @@ describe('assessmentsRouter', () => {
   describe('DELETE /curriculum/:curriculumAssessmentId', () => {});
 
   describe('GET /program/:programAssessmentId', () => {
-    it('should respond with a BadRequestError if given an invalid program assessment ID', done => {});
+    it('should respond with a program assessment when user is facilitator and program assessment in database', done => {
+      // mock service file responses
+        // findProgramAssessment
+      mockFindProgramAssessment.mockResolvedValue(exampleProgramAssessment);
+        // getPrincipalProgramRole
+      mockGetPrincipalProgramRole.mockResolvedValue('Facilitator');
+        // getCurriculumAssessment
+      mockGetCurriculumAssessment.mockResolvedValue(exampleCurriculumAssessmentWithCorrectAnswers);
+
+      // mock principal ID
+      mockPrincipalId(facilitatorPrincipalId);
+
+      // app agent
+      appAgent
+        .get(`/program/${exampleProgramAssessment.id}`)
+        .expect(
+          200,
+          itemEnvelope(exampleAssessmentDetails),
+          err => {
+        // mock service file calls
+          // findProgramAssessment
+          expect(mockFindProgramAssessment).toHaveBeenCalledWith(
+            exampleProgramAssessment.id
+          );
+
+          // getPrincipalProgramRole
+          expect(mockGetPrincipalProgramRole).toHaveBeenCalledWith(
+            facilitatorPrincipalId,
+            exampleProgramAssessment.program_id
+          );
+
+          // getCurriculumAssessment
+
+          expect(mockGetCurriculumAssessment).toHaveBeenCalledWith(
+            exampleProgramAssessment.assessment_id,
+            true,
+            true
+          );
+
+          // done
+          done(err);
+        }
+      );
+    });
+
+    // it('should respond with a BadRequestError if given an invalid program assessment ID', done => {
+
+    // });
+
+    // it('should respond with a NotFoundError if given a program assessment ID not in the database', done => {
+
+    // });
+    // it('should respond with a UnauthorizedError if someone other than a facilitator accesses the route', done => {
+
+    // });
   });
   describe('POST /program', () => {});
   describe('PUT /program/:programAssessmentId', () => {

--- a/api/src/middleware/assessmentsRouter.ts
+++ b/api/src/middleware/assessmentsRouter.ts
@@ -221,7 +221,6 @@ assessmentsRouter.get(
   async (req, res, next) => {
 
     const { principalId } = req.session;
-    console.log('principal id:', principalId);
 
     // get and parse the program assessment row ID number
     // error out if we were passed an invalid program assessment row ID number

--- a/api/src/middleware/assessmentsRouter.ts
+++ b/api/src/middleware/assessmentsRouter.ts
@@ -309,7 +309,6 @@ assessmentsRouter.delete(
 assessmentsRouter.get(
   '/program/:programAssessmentId',
   async (req, res, next) => {
-
     const { principalId } = req.session;
 
     // get and parse the program assessment row ID number
@@ -317,8 +316,11 @@ assessmentsRouter.get(
 
     const { programAssessmentId } = req.params;
     const programAssessmentIdParsed = Number(programAssessmentId);
-  
-    if (!Number.isInteger(programAssessmentIdParsed) || programAssessmentIdParsed < 1) {
+
+    if (
+      !Number.isInteger(programAssessmentIdParsed) ||
+      programAssessmentIdParsed < 1
+    ) {
       next(
         new BadRequestError(
           `"${programAssessmentIdParsed}" is not a valid submission ID.`
@@ -326,9 +328,11 @@ assessmentsRouter.get(
       );
       return;
     }
-  
+
     try {
-      const programAssessment = await findProgramAssessment(programAssessmentIdParsed);
+      const programAssessment = await findProgramAssessment(
+        programAssessmentIdParsed
+      );
 
       // if programAssessment is null
       // programAssessment.nil?
@@ -337,41 +341,43 @@ assessmentsRouter.get(
           `Could not find program assessment with ID ${programAssessmentIdParsed}.`
         );
       }
-  
+
       // get the principal program role
       const programRole = await getPrincipalProgramRole(
         principalId,
         programAssessment.program_id
       );
-  
+
       // if the program role is null/falsy, that means the user is not enrolled in
       // the program. send an error back to the user.
-      if (programRole !== "Facilitator") {
-        throw new UnauthorizedError(`Could not access assessment with Program Assessment ID ${programAssessmentIdParsed}.`);
+      if (programRole !== 'Facilitator') {
+        throw new UnauthorizedError(
+          `Could not access assessment with Program Assessment ID ${programAssessmentIdParsed}.`
+        );
       }
-  
+
       // for this route, we always want to return the questions and all answer
       // options in all cases.
       const includeQuestionsAndAllAnswers = true;
-  
+
       // if the program role is facilitator, we should always return the correct
       // answers. otherwise, return the correct answers only if the submission has
       // been graded.
       const includeQuestionsAndCorrectAnswers = true;
-  
+
       // get the curriculum assessment
       const curriculumAssessment = await getCurriculumAssessment(
         programAssessment.assessment_id,
         includeQuestionsAndAllAnswers,
         includeQuestionsAndCorrectAnswers
       );
-  
+
       // let's construct our return value
       const assessmentDetails: AssessmentDetails = {
         curriculum_assessment: curriculumAssessment,
         program_assessment: programAssessment,
       };
-  
+
       // let's return that to the user
       res.json(itemEnvelope(assessmentDetails));
     } catch (err) {

--- a/api/src/services/assessmentsService.ts
+++ b/api/src/services/assessmentsService.ts
@@ -245,7 +245,9 @@ export const listAssessmentQuestions = async (
       const correctAnswer = assessmentQuestion.answers.find(
         answer => answer.id === assessmentQuestionsRow.correct_answer_id
       );
-      correctAnswer.correct_answer = true;
+      if (correctAnswer) {
+        correctAnswer.correct_answer = true;
+      }
     }
 
     assessmentQuestions.push(assessmentQuestion);


### PR DESCRIPTION
## Proposed changes

This PR closes the [#572](https://github.com/OpenTree-Education/rhizone-lms/issues/572) issue. The GET /program/programAssessmentId route grabs a specific assessment from the database. This route has been created along with the testing required to ensure it is working properly for future developments. 

## Checklist

- [x] Related issue appears at beginning of pull request title with pound sign, and title describes the changes being proposed.
- [x] Related issue is linked in pull request description using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] The appropriate label has been chosen for this pull request.
- [x] The correct project has been selected for this pull request.
- [x] All commits in this branch, including merge commits, begin with the issue number and a pound sign.
- [x] Tests have been added, where appropriate; or, no tests are relevant for this pull request.
- [ ] This pull request contains UI changes, and screenshots of those UI images appear below; or, this pull request contains no UI changes.
